### PR TITLE
Unset flag once subgraph updated

### DIFF
--- a/packages/router/src/listener.ts
+++ b/packages/router/src/listener.ts
@@ -58,4 +58,9 @@ export async function setupListeners(
     const requestContext = createRequestContext("ReceiverTransactionFulfilled");
     await handler.handleReceiverFulfill(senderEvent, receiverEvent, requestContext);
   });
+
+  subgraph.attach(SubgraphEvents.ReceiverTransactionPrepared, async ({ senderEvent, receiverEvent }) => {
+    const requestContext = createRequestContext("ReceiverTransactionPrepared");
+    await handler.handleReceiverPrepare(senderEvent, receiverEvent, requestContext);
+  });
 }


### PR DESCRIPTION
Router submits duplicate txs to chain because of a race between router handling the tx and the subgraph being properly updated. This PR updates the flags to be unset only when the subgraph is updated. 

**NOTE**: Not sure if this is the best approach to prevent duplicate receiver-fulfill handlings. Doing so would mean querying the `SenderFulfilled` transactions, which would be an ever-growing list.