### PR TITLE
Adjustments

### DIFF
--- a/packages/router/src/contract.ts
+++ b/packages/router/src/contract.ts
@@ -401,7 +401,6 @@ export class TransactionManager {
         chainId,
         data: routerBalancesData,
         to: nxtpContractAddress,
-        value: 0,
       }),
       (err) =>
         new TransactionManagerError(TransactionManagerError.reasons.TxServiceError, {

--- a/packages/txservice/src/provider.ts
+++ b/packages/txservice/src/provider.ts
@@ -8,7 +8,7 @@ import { BaseLogger } from "pino";
 
 import { TransactionServiceConfig, ProviderConfig, validateProviderConfig, ChainConfig } from "./config";
 import { parseError, RpcError, TransactionError, TransactionReadError, TransactionServiceFailure } from "./error";
-import { FullTransaction, WriteTransaction, CachedGas, ReadTransaction } from "./types";
+import { FullTransaction, CachedGas, ReadTransaction } from "./types";
 
 const { StaticJsonRpcProvider, FallbackProvider } = providers;
 

--- a/packages/txservice/src/provider.ts
+++ b/packages/txservice/src/provider.ts
@@ -8,7 +8,7 @@ import { BaseLogger } from "pino";
 
 import { TransactionServiceConfig, ProviderConfig, validateProviderConfig, ChainConfig } from "./config";
 import { parseError, RpcError, TransactionError, TransactionReadError, TransactionServiceFailure } from "./error";
-import { FullTransaction, MinimalTransaction, CachedGas } from "./types";
+import { FullTransaction, WriteTransaction, CachedGas, ReadTransaction } from "./types";
 
 const { StaticJsonRpcProvider, FallbackProvider } = providers;
 
@@ -158,7 +158,7 @@ export class ChainRpcProvider {
    * @throws ChainError.reasons.ContractReadFailure in the event of a failure
    * to read from chain.
    */
-  public readTransaction(tx: MinimalTransaction): ResultAsync<string, TransactionError> {
+  public readTransaction(tx: ReadTransaction): ResultAsync<string, TransactionError> {
     return this.resultWrapper<string>(this.readTransaction.name, async () => {
       try {
         const readResult = await this.signer.call(tx);

--- a/packages/txservice/src/transaction.ts
+++ b/packages/txservice/src/transaction.ts
@@ -5,7 +5,7 @@ import { getUuid } from "@connext/nxtp-utils";
 import { TransactionServiceConfig } from "./config";
 // import { ChainError } from "./error";
 import { ChainRpcProvider } from "./provider";
-import { FullTransaction, GasPrice, MinimalTransaction } from "./types";
+import { FullTransaction, GasPrice, WriteTransaction } from "./types";
 import { NonceExpired, TransactionReplaced, TransactionReverted, TransactionServiceFailure } from "./error";
 
 /**
@@ -83,7 +83,7 @@ export class Transaction {
   private constructor(
     private readonly logger: BaseLogger,
     private readonly provider: ChainRpcProvider,
-    private readonly minTx: MinimalTransaction,
+    private readonly minTx: WriteTransaction,
     private readonly config: TransactionServiceConfig,
     private readonly gasPrice: GasPrice,
   ) {}
@@ -100,7 +100,7 @@ export class Transaction {
   static async create(
     logger: BaseLogger,
     provider: ChainRpcProvider,
-    minTx: MinimalTransaction,
+    minTx: WriteTransaction,
     config: TransactionServiceConfig,
   ): Promise<Transaction> {
     const result = await provider.getGasPrice();

--- a/packages/txservice/src/transaction.ts
+++ b/packages/txservice/src/transaction.ts
@@ -3,7 +3,6 @@ import { BaseLogger } from "pino";
 import { getUuid } from "@connext/nxtp-utils";
 
 import { TransactionServiceConfig } from "./config";
-// import { ChainError } from "./error";
 import { ChainRpcProvider } from "./provider";
 import { FullTransaction, GasPrice, WriteTransaction } from "./types";
 import { NonceExpired, TransactionReplaced, TransactionReverted, TransactionServiceFailure } from "./error";

--- a/packages/txservice/src/txservice.ts
+++ b/packages/txservice/src/txservice.ts
@@ -140,11 +140,9 @@ export class TransactionService {
               "Tx was already mined, procceeding to confirmation step.",
             );
           } else {
-            // TODO: Check to see if the error is an AlreadyMined error, as we probably don't need to
-            // log this here if it is.
             this.logger.warn(
               { method, methodId, requestContext, error },
-              "Tx submit failed due to reason other than AlreadyMined.",
+              "Tx submit failed for unexpected reason.",
             );
           }
           // Save the submit error to indicate we've failed here; this should be the last execution

--- a/packages/txservice/src/txservice.ts
+++ b/packages/txservice/src/txservice.ts
@@ -5,7 +5,7 @@ import { Evt } from "evt";
 import { getUuid, jsonifyError, RequestContext } from "@connext/nxtp-utils";
 
 import { TransactionServiceConfig, validateTransactionServiceConfig, DEFAULT_CONFIG, ChainConfig } from "./config";
-import { MinimalTransaction } from "./types";
+import { ReadTransaction, WriteTransaction } from "./types";
 import { ChainRpcProvider } from "./provider";
 import { Transaction } from "./transaction";
 import { TimeoutError, TransactionError, TransactionServiceFailure } from "./error";
@@ -115,7 +115,7 @@ export class TransactionService {
    * something went wrong within TransactionService process.
    * @throws TransactionServiceFailure, which indicates something went wrong with the service logic.
    */
-  public async sendTx(tx: MinimalTransaction, requestContext: RequestContext): Promise<providers.TransactionReceipt> {
+  public async sendTx(tx: WriteTransaction, requestContext: RequestContext): Promise<providers.TransactionReceipt> {
     const method = this.sendTx.name;
     const methodId = getUuid();
     this.logger.info({ method, methodId, requestContext, tx }, "Method start");
@@ -174,16 +174,14 @@ export class TransactionService {
   /**
    * Create a non-state changing contract call. Returns hexdata that needs to be decoded.
    *
-   * @param tx - Data to read
+   * @param tx - ReadTransaction to create contract call
    * @param tx.chainId - Chain to read transaction on
    * @param tx.to - Address to execute read on
-   * @param tx.value - Value to execute read tx with
    * @param tx.data - Calldata to send
-   * @param tx.from - (optional) Account to send tx from
+   * 
    * @returns Encoded hexdata representing result of the read from the chain.
    */
-  // TODO: read will never have a value/from, why include it in the type
-  public async readTx(tx: MinimalTransaction): Promise<string> {
+  public async readTx(tx: ReadTransaction): Promise<string> {
     const result = await this.getProvider(tx.chainId).readTransaction(tx);
     if (result.isErr()) {
       throw result.error;

--- a/packages/txservice/src/types.ts
+++ b/packages/txservice/src/types.ts
@@ -2,7 +2,13 @@ import { BigNumber, BigNumberish } from "ethers";
 
 import { TransactionServiceFailure } from "./error";
 
-export type MinimalTransaction = {
+export type ReadTransaction = {
+  chainId: number;
+  to: string;
+  data: string;
+};
+
+export type WriteTransaction = {
   chainId: number;
   to: string;
   value: BigNumberish;
@@ -13,7 +19,7 @@ export type MinimalTransaction = {
 export type FullTransaction = {
   nonce?: number;
   gasPrice: BigNumber;
-} & MinimalTransaction;
+} & WriteTransaction;
 
 export type CachedGas = {
   price: BigNumber;

--- a/packages/txservice/src/types.ts
+++ b/packages/txservice/src/types.ts
@@ -9,12 +9,9 @@ export type ReadTransaction = {
 };
 
 export type WriteTransaction = {
-  chainId: number;
-  to: string;
-  value: BigNumberish;
-  data: string;
   from?: string;
-};
+  value: BigNumberish;
+} & ReadTransaction;
 
 export type FullTransaction = {
   nonce?: number;

--- a/packages/txservice/test/constants.ts
+++ b/packages/txservice/test/constants.ts
@@ -2,12 +2,12 @@ import { providers, BigNumber } from "ethers";
 import { AddressZero, One, Zero } from "@ethersproject/constants";
 import { mkHash, mkAddress } from "@connext/nxtp-utils";
 
-import { MinimalTransaction } from "../src/types";
+import { WriteTransaction } from "../src/types";
 
 type TransactionReceipt = providers.TransactionReceipt;
 type TransactionResponse = providers.TransactionResponse;
 
-export const tx: MinimalTransaction = {
+export const tx: WriteTransaction = {
   chainId: 1337,
   to: AddressZero,
   from: AddressZero,


### PR DESCRIPTION
Minor adjustments to tx service logic including:

- ReadTransaction type with the `value` and `from` fields removed: for doing tx reads.

- prevents this (supposedly impossible case) from happening with a flag: "submitFailed".
    tx submit -> success -> confirm -> timeout -> bump gas -> tx submit -> revert! -> confirm -> timeout (?*) -> bump gas ??!? -> tx submit ??!?
If `submitFailed`, then we only try to confirm once.

- various sanity checks