### PR TITLE
[router] 4.11: newAuction validators

### DIFF
--- a/packages/integration/test/load/txserviceConcurrency.ts
+++ b/packages/integration/test/load/txserviceConcurrency.ts
@@ -3,6 +3,7 @@ import PriorityQueue from "p-queue";
 import { ChainConfig, TransactionService, WriteTransaction } from "@connext/nxtp-txservice";
 import { RequestContext } from "@connext/nxtp-utils";
 import { BigNumber, Contract, utils } from "ethers";
+// eslint-disable-next-line node/no-extraneous-import
 import { Zero } from "@ethersproject/constants";
 
 import { getConfig } from "../utils/config";
@@ -167,8 +168,8 @@ const txserviceConcurrencyTest = async (maxConcurrency: number, step = 1, localC
     const iterationData = {
       loopNumber,
       concurrency,
-      averageExecutionTime: `${avgExecutionTime / 60} min`,
-      medianExecutionTime: `${executionTimes[Math.floor(executionTimes.length / 2)]} min`,
+      averageExecutionTime: `${Math.round(100 * (avgExecutionTime / 1000)) / 100}s`,
+      medianExecutionTime: `${Math.round(100 * (executionTimes[Math.floor(executionTimes.length / 2)] / 3600)) / 1000}s`,
       errored: errored.length,
       successful: results.length - errored.length,
       errors,

--- a/packages/integration/test/utils/config.ts
+++ b/packages/integration/test/utils/config.ts
@@ -91,4 +91,3 @@ export const getConfig = (useDefaultLocal = false): Config => {
   };
 };
 
-export const config: Config = getConfig();

--- a/packages/router/src/lib/errors/auction.ts
+++ b/packages/router/src/lib/errors/auction.ts
@@ -10,7 +10,7 @@ export class NotEnoughLiquidity extends NxtpError {
 
 export class ZeroValueBid extends NxtpError {
   constructor(context: any = {}) {
-    super("Amount for request was invalid: it must be greater than 0", context, "ZeroAmountRequest");
+    super("Amount for request was invalid: must be integer greater than 0", context, "ZeroAmountRequest");
   }
 }
 

--- a/packages/router/src/lib/errors/auction.ts
+++ b/packages/router/src/lib/errors/auction.ts
@@ -8,9 +8,15 @@ export class NotEnoughLiquidity extends NxtpError {
   }
 }
 
-export class ZeroAmountRequest extends NxtpError {
+export class ZeroValueBid extends NxtpError {
   constructor(context: any = {}) {
     super("Amount for request was invalid: it must be greater than 0", context, "ZeroAmountRequest");
+  }
+}
+
+export class AuctionExpired extends NxtpError {
+  constructor(expiry: number, context: any = {}) {
+    super(`Auction is past (or too close to) expiry: ${expiry}`, context, "AuctionExpired");
   }
 }
 

--- a/packages/router/src/lib/errors/auction.ts
+++ b/packages/router/src/lib/errors/auction.ts
@@ -8,6 +8,12 @@ export class NotEnoughLiquidity extends NxtpError {
   }
 }
 
+export class ZeroAmountRequest extends NxtpError {
+  constructor(context: any = {}) {
+    super("Amount for request was invalid: it must be greater than 0", context, "ZeroAmountRequest");
+  }
+}
+
 export class ProvidersNotAvailable extends NxtpError {
   constructor(chainIds: number[], context: any = {}) {
     super(`Providers not available for chainIds ${chainIds.join(",")}`, context, "ProvidersNotAvailable");

--- a/packages/router/src/lib/errors/index.ts
+++ b/packages/router/src/lib/errors/index.ts
@@ -1,4 +1,4 @@
-export { NotEnoughLiquidity, ProvidersNotAvailable, SwapInvalid, NotEnoughGas, ZeroAmountRequest } from "./auction";
+export { NotEnoughLiquidity, ProvidersNotAvailable, SwapInvalid, NotEnoughGas, ZeroValueBid, AuctionExpired } from "./auction";
 
 export { ContractReaderNotAvailableForChain } from "./contractReader";
 

--- a/packages/router/src/lib/errors/index.ts
+++ b/packages/router/src/lib/errors/index.ts
@@ -1,4 +1,4 @@
-export { NotEnoughLiquidity, ProvidersNotAvailable, SwapInvalid, NotEnoughGas } from "./auction";
+export { NotEnoughLiquidity, ProvidersNotAvailable, SwapInvalid, NotEnoughGas, ZeroAmountRequest } from "./auction";
 
 export { ContractReaderNotAvailableForChain } from "./contractReader";
 

--- a/packages/router/src/lib/operations/auction.ts
+++ b/packages/router/src/lib/operations/auction.ts
@@ -1,4 +1,5 @@
 import { AuctionBid, AuctionPayload, getUuid, RequestContext, signAuctionBid } from "@connext/nxtp-utils";
+import { BigNumber } from "ethers";
 import { getAddress } from "ethers/lib/utils";
 
 import { getContext } from "../../router";
@@ -36,7 +37,7 @@ export const newAuction = async (
 
   // Validate that amount > 0. This would fail when later calling the contract,
   // thus exposing a potential gas griefing attack vector w/o this step.
-  if (parseInt(amount) <= 0) {
+  if (BigNumber.from(amount).isZero()) {
     throw new ZeroValueBid({
       methodId,
       method,

--- a/packages/router/src/lib/operations/auction.ts
+++ b/packages/router/src/lib/operations/auction.ts
@@ -35,9 +35,16 @@ export const newAuction = async (
 
   // TODO: Implement rate limit per user (approximately 1/5s ?).
 
-  // Validate that amount > 0. This would fail when later calling the contract,
-  // thus exposing a potential gas griefing attack vector w/o this step.
-  if (BigNumber.from(amount).isZero()) {
+  try {
+    // Using try/catch in case amount is invalid number (e.g. negative, decimal, etc).
+    const amountBigNumber = BigNumber.from(amount);
+    // Validate that amount > 0. This would fail when later calling the contract,
+    // thus exposing a potential gas griefing attack vector w/o this step.
+    if (amountBigNumber.isZero()) {
+      // Throwing empty error as the ZeroValueBid error below will override it.
+      throw new Error("Amount was zero.");
+    }
+  } catch (e) {
     throw new ZeroValueBid({
       methodId,
       method,
@@ -45,6 +52,7 @@ export const newAuction = async (
       amount,
       receivingAssetId,
       receivingChainId,
+      error: e.message,
     });
   }
 


### PR DESCRIPTION
Fixes #158 

WARNING: Did NOT address the following:
- "remove debug code from production build ( dry-run )" : assuming we need this for now. Left a TODO.

- "signer address might be different for different chains" : according to @LayneHaber this isn't actually possible, so non-issue.

- "no rate limiting. potential DoS vector when someone floods the node with auction requests (significant work to be done, handler is async, will trigger a reply message). user might force the router to sign the same message multiple times" : left a TODO, but not sure if this would realistically be implemented here or in the router index. I would imagine the latter.

- "actual estimated gas required to fuel transaction is never checked. current balance might be outdated, especially in race condition scenarios." @LayneHaber @rhlsthrm lmk if this should be addressed. It's tough bc I believe an estimateGas and getGasPrice call will have to be made regardless (as in, we could check "ahead of time" to make sure both wallets can afford this tx, but the reality is that we would just end up making that same call anyway when we move to execute... not sure if that would really solve anything).