### PR TITLE
204 expiry

### DIFF
--- a/packages/router/src/adapters/subgraph/index.ts
+++ b/packages/router/src/adapters/subgraph/index.ts
@@ -7,6 +7,7 @@ import { getContext } from "../../router";
 
 import { getSdk, Sdk } from "./graphqlsdk";
 import { getActiveTransactions, getAssetBalance, getTransactionForChain } from "./subgraph";
+import { getBlockTime } from "./provider";
 
 export type ContractReader = {
   getActiveTransactions: () => Promise<ActiveTransaction<any>[]>;
@@ -25,6 +26,13 @@ export type ContractReader = {
    * @returns The available balance (or undefined)
    */
   getAssetBalance: (assetId: string, chainId: number) => Promise<BigNumber>;
+
+  /**
+   * Returns the block.timestamp of the latest block on the given chain
+   *
+   * @param chainId - Chain you want blocktime on
+   */
+  getBlockTime: (chainId: number) => Promise<number>;
 };
 
 const sdks: Record<number, Sdk> = {};
@@ -47,5 +55,6 @@ export const subgraphContractReader = (): ContractReader => {
     getActiveTransactions,
     getTransactionForChain,
     getAssetBalance,
+    getBlockTime,
   };
 };

--- a/packages/router/src/adapters/subgraph/provider.ts
+++ b/packages/router/src/adapters/subgraph/provider.ts
@@ -1,0 +1,21 @@
+import { providers } from "ethers";
+
+import { ContractReaderNotAvailableForChain } from "../../lib/errors";
+import { getContext } from "../../router";
+
+/** Functions where the provider is used instead of a subgraph */
+export const getBlockTime = async (chainId: number): Promise<number> => {
+  const { config } = getContext();
+
+  if (!Object.keys(config.chainConfig).includes(chainId.toString())) {
+    throw new ContractReaderNotAvailableForChain(chainId, { available: Object.keys(chainId) });
+  }
+
+  const urls = config.chainConfig[chainId].providers;
+  const provider =
+    urls.length === 1
+      ? new providers.JsonRpcProvider(urls[0])
+      : new providers.FallbackProvider(urls.map((url) => new providers.JsonRpcProvider(url), 1));
+  const block = await provider.getBlock("latest");
+  return block.timestamp;
+};

--- a/packages/router/src/adapters/subgraph/provider.ts
+++ b/packages/router/src/adapters/subgraph/provider.ts
@@ -1,4 +1,5 @@
-import { providers } from "ethers";
+import { providers, Contract, constants } from "ethers";
+import { ERC20Abi } from "@connext/nxtp-utils";
 
 import { ContractReaderNotAvailableForChain } from "../../lib/errors";
 import { getContext } from "../../router";
@@ -18,4 +19,25 @@ export const getBlockTime = async (chainId: number): Promise<number> => {
       : new providers.FallbackProvider(urls.map((url) => new providers.JsonRpcProvider(url), 1));
   const block = await provider.getBlock("latest");
   return block.timestamp;
+};
+
+export const getAssetDecimals = async (assetId: string, chainId: number): Promise<number> => {
+  if (assetId === constants.AddressZero) {
+    return 18;
+  }
+
+  const { config } = getContext();
+
+  if (!Object.keys(config.chainConfig).includes(chainId.toString())) {
+    throw new ContractReaderNotAvailableForChain(chainId, { available: Object.keys(chainId) });
+  }
+
+  // Get provider
+  const urls = config.chainConfig[chainId].providers;
+  const provider =
+    urls.length === 1
+      ? new providers.JsonRpcProvider(urls[0])
+      : new providers.FallbackProvider(urls.map((url) => new providers.JsonRpcProvider(url), 1));
+
+  return new Contract(assetId, ERC20Abi, provider).decimals();
 };

--- a/packages/router/src/lib/helpers/auction.ts
+++ b/packages/router/src/lib/helpers/auction.ts
@@ -1,6 +1,8 @@
 /**
  * Gets the expiry on a given auction bid
  *
+ * @remarks Fine for bid expiry to use local clock, since only router will be validating the bid timestamp
+ *
  * @returns Expiry time of a given bid in s
  */
 export const getBidExpiry = () => Math.floor(Date.now() / 1000) + 60 * 5;

--- a/packages/router/src/lib/helpers/index.ts
+++ b/packages/router/src/lib/helpers/index.ts
@@ -1,3 +1,9 @@
-export { getReceiverAmount, getReceiverExpiry, recoverAuctionBid, validExpiry, decodeAuctionBid } from "./prepare";
+export {
+  getReceiverAmount,
+  getReceiverExpiryBuffer,
+  recoverAuctionBid,
+  validExpiryBuffer,
+  decodeAuctionBid,
+} from "./prepare";
 
 export { getBidExpiry } from "./auction";

--- a/packages/router/src/lib/helpers/prepare.ts
+++ b/packages/router/src/lib/helpers/prepare.ts
@@ -9,8 +9,14 @@ const EXPIRY_DECREMENT = 3600 * 24;
 const SWAP_RATE = "0.9995"; // 0.05% fee
 const ONE_DAY_IN_SECONDS = 3600 * 24;
 
-/** Determine if expiry is valid */
-export const validExpiry = (expiry: number) => expiry - Math.floor(Date.now() / 1000) > ONE_DAY_IN_SECONDS;
+/**
+ * Determine if expiry is valid
+ *
+ * @remarks Should use the latest block of the *receiving* chain
+ *
+ * @param buffer - The expiry buffer to check validity of
+ */
+export const validExpiryBuffer = (buffer: number) => buffer > ONE_DAY_IN_SECONDS;
 
 /**
  * Returns the amount * SWAP_RATE to deduct fees when going from sending -> recieving chain to incentivize routing.
@@ -28,14 +34,14 @@ export const getReceiverAmount = (amount: string) => {
 /**
  * Returns the expiry - EXPIRY_DECREMENT to ensure the receiving-side transfer expires prior to the sending-side transfer.
  *
- * @param expiry The expiry of the transaction on the sending chain
+ * @param buffer The expiry of the transaction on the sending chain
  * @returns The expiry for the receiving-chain transaction (expires sooner than the sending-chain transaction)
  *
  * @remarks
  * Recieiving chain expires first to force the secret to be revealed on the receiving side before the sending side expires
  */
-export const getReceiverExpiry = (expiry: number): number => {
-  const rxExpiry = expiry - EXPIRY_DECREMENT;
+export const getReceiverExpiryBuffer = (buffer: number): number => {
+  const rxExpiry = buffer - EXPIRY_DECREMENT;
   return rxExpiry;
 };
 

--- a/packages/router/src/lib/helpers/prepare.ts
+++ b/packages/router/src/lib/helpers/prepare.ts
@@ -11,6 +11,7 @@ import { AmountInvalid } from "../errors/prepare";
 const EXPIRY_DECREMENT = 3600 * 24;
 const SWAP_RATE = "0.9995"; // 0.05% fee
 const ONE_DAY_IN_SECONDS = 3600 * 24;
+const ONE_WEEK_IN_SECONDS = 3600 * 24 * 7;
 
 /**
  * Determine if expiry is valid
@@ -19,7 +20,7 @@ const ONE_DAY_IN_SECONDS = 3600 * 24;
  *
  * @param buffer - The expiry buffer to check validity of
  */
-export const validExpiryBuffer = (buffer: number) => buffer > ONE_DAY_IN_SECONDS;
+export const validExpiryBuffer = (buffer: number) => buffer > ONE_DAY_IN_SECONDS && buffer < ONE_WEEK_IN_SECONDS;
 
 /**
  * Returns the amount * SWAP_RATE to deduct fees when going from sending -> recieving chain to incentivize routing.

--- a/packages/router/src/lib/operations/prepare.ts
+++ b/packages/router/src/lib/operations/prepare.ts
@@ -4,7 +4,13 @@ import { BigNumber, providers } from "ethers/lib/ethers";
 import { getContext } from "../../router";
 import { PrepareInput } from "../entities";
 import { AuctionSignerInvalid, ExpiryInvalid, NotEnoughLiquidity, SenderChainDataInvalid } from "../errors";
-import { decodeAuctionBid, getReceiverAmount, getReceiverExpiry, recoverAuctionBid, validExpiry } from "../helpers";
+import {
+  decodeAuctionBid,
+  getReceiverAmount,
+  getReceiverExpiryBuffer,
+  recoverAuctionBid,
+  validExpiryBuffer,
+} from "../helpers";
 
 export const receiverPreparing: Map<string, boolean> = new Map();
 
@@ -46,10 +52,34 @@ export const prepare = async (
     throw new NotEnoughLiquidity(invariantData.receivingChainId, { method, methodId, requestContext });
   }
 
-  const receiverExpiry = getReceiverExpiry(senderExpiry);
-  if (!validExpiry(receiverExpiry)) {
+  // Handle the expiries.
+  // Some notes on expiries -- each participant should be using the latest
+  // block timestamp as the baseline for evaluating the expiries rather than
+  // the Date.now() to avoid local clock errors. The block.timestamp should
+  // be evaluated against the chain they are preparing on (i.e. user refs
+  // sending chain and router refs receiving chain).
+
+  // Get current block times
+  const currentBlockTimeReceivingChain = await contractReader.getBlockTime(invariantData.receivingChainId);
+  const currentBlockTimeSendingChain = await contractReader.getBlockTime(invariantData.sendingChainId);
+
+  // Get buffers
+  const senderBuffer = senderExpiry - currentBlockTimeSendingChain;
+  const receiverBuffer = getReceiverExpiryBuffer(senderBuffer);
+
+  // Calculate receiver expiry
+  const receiverExpiry = receiverBuffer + currentBlockTimeReceivingChain;
+
+  if (!validExpiryBuffer(receiverBuffer)) {
     // cancellable error
-    throw new ExpiryInvalid(receiverExpiry, { method, methodId, requestContext, senderExpiry });
+    throw new ExpiryInvalid(receiverExpiry, {
+      method,
+      methodId,
+      requestContext,
+      senderExpiry,
+      senderBuffer,
+      receiverBuffer,
+    });
   }
 
   logger.info({ method, methodId, requestContext }, "Validated input");

--- a/packages/router/src/lib/operations/prepare.ts
+++ b/packages/router/src/lib/operations/prepare.ts
@@ -49,7 +49,7 @@ export const prepare = async (
   const receiverExpiry = getReceiverExpiry(senderExpiry);
   if (!validExpiry(receiverExpiry)) {
     // cancellable error
-    throw new ExpiryInvalid(receiverExpiry, { method, methodId, requestContext });
+    throw new ExpiryInvalid(receiverExpiry, { method, methodId, requestContext, senderExpiry });
   }
 
   logger.info({ method, methodId, requestContext }, "Validated input");

--- a/packages/router/test/globalTestHook.ts
+++ b/packages/router/test/globalTestHook.ts
@@ -40,6 +40,7 @@ export const mochaHooks = {
       getAssetBalance: stub().resolves(BigNumber.from("10001")),
       getTransactionForChain: stub().resolves(singleChainTransactionMock),
       getAssetDecimals: stub().resolves(18),
+      getBlockTime: stub().resolves(Math.floor(Date.now() / 1000)),
     };
 
     contractWriterMock = {

--- a/packages/router/test/lib/operations/auction.spec.ts
+++ b/packages/router/test/lib/operations/auction.spec.ts
@@ -6,7 +6,7 @@ import { expect } from "@connext/nxtp-utils/src/expect";
 import { newAuction } from "../../../src/lib/operations";
 import * as PrepareHelperFns from "../../../src/lib/helpers/prepare";
 import * as AuctionHelperFns from "../../../src/lib/helpers/auction";
-import { BID_EXPIRY, configMock, MUTATED_AMOUNT, MUTATED_EXPIRY, routerAddrMock } from "../../utils";
+import { BID_EXPIRY, configMock, MUTATED_AMOUNT, MUTATED_BUFFER, MUTATED_EXPIRY, routerAddrMock } from "../../utils";
 import { txServiceMock } from "../../globalTestHook";
 import { constants } from "ethers/lib/ethers";
 
@@ -34,7 +34,7 @@ describe("Auction Operation", () => {
   describe("#newAuction", () => {
     beforeEach(() => {
       getReceiverAmountStub = stub(PrepareHelperFns, "getReceiverAmount").returns(MUTATED_AMOUNT);
-      stub(PrepareHelperFns, "getReceiverExpiry").returns(MUTATED_EXPIRY);
+      stub(PrepareHelperFns, "getReceiverExpiryBuffer").returns(MUTATED_BUFFER);
 
       stub(AuctionHelperFns, "getBidExpiry").returns(BID_EXPIRY);
     });

--- a/packages/router/test/utils.ts
+++ b/packages/router/test/utils.ts
@@ -15,7 +15,7 @@ import {
 export const routerAddrMock = mkAddress("0xb");
 
 export const MUTATED_AMOUNT = "100";
-export const MUTATED_EXPIRY = 123400;
+export const MUTATED_BUFFER = 123400;
 export const BID_EXPIRY = 123401;
 
 export const configMock: NxtpRouterConfig = {

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -50,13 +50,15 @@ import {
 import { Subgraph, SubgraphEvent, SubgraphEvents, ActiveTransaction } from "./subgraph";
 
 /** Gets the expiry to use for new transfers */
-export const getExpiry = () => Math.floor(Date.now() / 1000) + 3600 * 24 * 3;
+const hoursToSeconds = (hours: number) => hours * 60 * 60;
+const daysToSeconds = (days: number) => hoursToSeconds(days * 24);
+export const getExpiry = () => Math.floor(Date.now() / 1000) + daysToSeconds(3) + hoursToSeconds(3);
 
 /** Gets the min expiry buffer to validate */
-export const getMinExpiryBuffer = () => 3600 * 24 * 2 + 3600; // 2 days + 1 hour
+export const getMinExpiryBuffer = () => daysToSeconds(2) + hoursToSeconds(1); // 2 days + 1 hour
 
 /** Gets the max expiry buffer to validate */
-export const getMaxExpiryBuffer = () => 3600 * 24 * 4; // 4 days
+export const getMaxExpiryBuffer = () => daysToSeconds(4); // 4 days
 
 export const MIN_SLIPPAGE_TOLERANCE = "00.01"; // 0.01%;
 export const MAX_SLIPPAGE_TOLERANCE = "15.00"; // 15.0%

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -52,7 +52,9 @@ import { Subgraph, SubgraphEvent, SubgraphEvents, ActiveTransaction } from "./su
 /** Gets the expiry to use for new transfers */
 const hoursToSeconds = (hours: number) => hours * 60 * 60;
 const daysToSeconds = (days: number) => hoursToSeconds(days * 24);
-export const getExpiry = () => Math.floor(Date.now() / 1000) + daysToSeconds(3) + hoursToSeconds(3);
+export const getExpiry = () => getTimestampInSeconds() + daysToSeconds(3) + hoursToSeconds(3);
+
+export const getTimestampInSeconds = () => Math.floor(Date.now() / 1000);
 
 /** Gets the min expiry buffer to validate */
 export const getMinExpiryBuffer = () => daysToSeconds(2) + hoursToSeconds(1); // 2 days + 1 hour
@@ -521,20 +523,20 @@ export class NxtpSdk {
     }
 
     const expiry = _expiry ?? getExpiry();
-    if (expiry - Date.now() / 1000 < getMinExpiryBuffer()) {
+    if (expiry - getTimestampInSeconds() < getMinExpiryBuffer()) {
       throw new NxtpSdkError(NxtpSdkError.reasons.ParamsError, {
         method,
         methodId,
-        paramsError: `Expiry too short, must be at least ${Date.now() / 1000 + getMinExpiryBuffer()}`,
+        paramsError: `Expiry too short, must be at least ${getTimestampInSeconds() + getMinExpiryBuffer()}`,
         transactionId: params.transactionId ?? "",
       });
     }
 
-    if (expiry - Date.now() / 1000 > getMaxExpiryBuffer()) {
+    if (expiry - getTimestampInSeconds() > getMaxExpiryBuffer()) {
       throw new NxtpSdkError(NxtpSdkError.reasons.ParamsError, {
         method,
         methodId,
-        paramsError: `Expiry too high, must be at below ${Date.now() / 1000 + getMaxExpiryBuffer()}`,
+        paramsError: `Expiry too high, must be at below ${getTimestampInSeconds() + getMaxExpiryBuffer()}`,
         transactionId: params.transactionId ?? "",
       });
     }

--- a/packages/sdk/test/unit/sdk.spec.ts
+++ b/packages/sdk/test/unit/sdk.spec.ts
@@ -44,7 +44,6 @@ describe("NxtpSdk", () => {
   let provider1338: SinonStubbedInstance<providers.FallbackProvider>;
   let signFulfillTransactionPayloadMock: SinonStub;
   let recoverAuctionBidMock: SinonStub;
-  let getDecimalsStub: SinonStub;
 
   let user: string = mkAddress("0xa");
   let router: string = mkAddress("0xb");
@@ -74,7 +73,9 @@ describe("NxtpSdk", () => {
     subgraph = createStubInstance(Subgraph);
     transactionManager = createStubInstance(TransactionManager);
 
-    getDecimalsStub = stub(sdkUtils, "getDecimals").resolves(18);
+    stub(sdkUtils, "getDecimals").resolves(18);
+
+    stub(sdkUtils, "getTimestampInSeconds").resolves(Math.floor(Date.now() / 1000));
 
     signFulfillTransactionPayloadMock = stub(sdkUtils, "signFulfillTransactionPayload");
     recoverAuctionBidMock = stub(sdkUtils, "recoverAuctionBid");


### PR DESCRIPTION
Fixes #204 

- Updates the sdk and router to use `block.timestamp` instead of `Date.now()` for all expiry related things