### PR TITLE
[DNM] [txservice] Serialized transaction validation

### DIFF
--- a/packages/txservice/src/dispatch.ts
+++ b/packages/txservice/src/dispatch.ts
@@ -1,0 +1,188 @@
+import { BigNumber, providers, Signer } from "ethers";
+import { BaseLogger } from "pino";
+import PriorityQueue from "p-queue";
+// import { getUuid } from "@connext/nxtp-utils";
+
+// import { TransactionServiceConfig } from "./config";
+import { ChainRpcProvider } from "./provider";
+import { FullTransaction, GasPrice, WriteTransaction } from "./types";
+import { AlreadyMined, TransactionReplaced, TransactionReverted, TransactionServiceFailure } from "./error";
+
+class MetaTransaction {
+  // Responses, in the order of attempts made for this tx.
+  public responses: providers.TransactionResponse[] = [];
+  // Receipt that we received for the on-chain transaction that was mined with
+  // the desired number of confirmations.
+  public receipt?: providers.TransactionReceipt;
+
+  // Which transaction attempt we are on.
+  private _attempt = 0;
+  /**
+   * Getter to return the internal attempt
+   *
+   * @returns The _attempt of the transction
+   */
+  public get attempt(): number {
+    return this._attempt;
+  }
+
+  /**
+   * Retrieves all data needed to format a full transaction, including current gas price set, nonce, etc.
+   */
+  public get data(): FullTransaction {
+    return {
+      ...this.minTx,
+      gasPrice: this.gasPrice.get(),
+      nonce: this.nonce,
+      gasLimit: this.gasPrice.limit,
+    };
+  }
+
+  /**
+   * A data structure used for management of the lifecycle of one on-chain transaction.
+   *
+   * @param logger The pino.BaseLogger instance we use for logging.
+   * @param provider The ChainRpcProvider instance we use for interfacing with the chain.
+   * @param minTx The minimum transaction data required to send a transaction.
+   * @param gasPrice Initialized gas price tracker for this transaction.
+   */
+  constructor(
+    public readonly minTx: WriteTransaction,
+    public readonly nonce: number,
+    private readonly gasPrice: GasPrice,
+  ) {}
+}
+
+// Thread safe stack manager.
+class TransactionBuffer {
+  // Both of the following are functionally treated as stacks (LIFO).
+  private completed: MetaTransaction[] = [];
+  private pending: MetaTransaction[] = [];
+  // Should be used to access either of the stacks.
+  private readonly accessQueue: PriorityQueue = new PriorityQueue({ concurrency: 1 });
+
+  // Push a new tx to pending.
+  public async push() {
+    // TODO: We may want to cap the pending stack here.
+  }
+
+  // Move latest pending to completed.
+  public async shift() {
+    // TODO: Trim the completed stack.
+  }
+
+  /**
+   * Get the current nonce value.
+   *
+   * @remarks
+   * Caller should still be prepared to get the incorrect nonce back. For instance,
+   * if the provider that just handled our sent tx has suddenly gone offline, this
+   * method may give the wrong nonce. This can be solved by making additional calls to
+   * submit the tx.
+   *
+   * @returns A number value for the current nonce.
+   */
+  public async getNonce(): Promise<number | undefined> {
+    // Update nonce value to greatest of all nonce values retrieved.
+    return (await this.getLastTx())?.nonce;
+  }
+
+  private async getLastTx(): Promise<MetaTransaction | null> {
+    return await this.accessQueue.add(() => {
+      if (this.pending.length > 0) {
+        return this.pending[this.pending.length - 1];
+      } else if (this.completed.length > 0) {
+        return this.completed[this.completed.length - 1];
+      }
+      return null;
+    });
+  }
+}
+
+export class RpcDispatch {
+  private readonly submitQueue: PriorityQueue = new PriorityQueue({ concurrency: 1 });
+  public readonly chainId: number;
+
+  /**
+   *
+   * @param logger The pino.BaseLogger instance we use for logging.
+   * @param provider The ChainRpcProvider instance we use for interfacing with the chain.
+   */
+  constructor(
+    private readonly logger: BaseLogger,
+    public readonly provider: ChainRpcProvider
+  ) {
+    this.chainId = this.provider.chainId;
+  }
+
+  public async submit(tx: WriteTransaction) {
+    let gasLimit: BigNumber;
+    let result = await this.provider.estimateGas(tx);
+    if (result.isErr()) {
+      if (result.error instanceof TransactionReverted) {
+        throw result.error;
+      }
+      this.logger.warn(
+        {
+          method: this.submit.name,
+          transaction: tx,
+          error: result.error,
+        },
+        "Estimate gas failed due to an unexpected error.",
+      );
+      throw result.error;
+    } else {
+      gasLimit = result.value;
+    }
+
+    result = await this.provider.getGasPrice();
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const gasPrice = new GasPrice(result.value, gasLimit);
+  
+
+    
+
+    // Queue up the execution of the transaction.
+    result = await this.submitQueue.add(
+      async (): Promise<{ value: MetaTx | Error; success: boolean }> => {
+        try {
+          // NOTE: This call must be serialized within the queue, as it is depenedent on pending transaction count.
+          const nonce = transaction.nonce ?? (await this.transactionBuffer.getNonce());
+
+          // Send the transaction.
+          const response = 
+
+          // Check to see if ethers returned null or undefined for the response; if so, handle as error case.
+          if (response == null) {
+            throw new TransactionServiceFailure("Ethers returned a null or undefined transaction response.", {
+              transaction,
+              response,
+            });
+          }
+
+          const value = this.transactionBuffer.push(nonce, response);
+          return { value, success: true };
+        } catch (e) {
+          return { value: e, success: false };
+        }
+      },
+    );
+    if (!result.success) {
+      throw result.value;
+    }
+    // Now we block until the transaction is validated (meaning that it's received 1 confirmation on chain).
+    const meta: MetaTx = result.value as MetaTx;
+    await meta.validate();
+    return meta.response;
+
+    // add to submit queue, new tx
+    // block until submit completed
+    // error ? throw. else...
+    // wait until 1 confirm
+    // timeout ?
+    // check to see if we are the
+  }
+
+}

--- a/packages/txservice/src/provider.ts
+++ b/packages/txservice/src/provider.ts
@@ -1,4 +1,4 @@
-import { delay, ERC20Abi, NxtpError } from "@connext/nxtp-utils";
+import { ERC20Abi, NxtpError } from "@connext/nxtp-utils";
 import axios from "axios";
 import { BigNumber, Signer, Wallet, providers, constants, Contract } from "ethers";
 import { okAsync, ResultAsync } from "neverthrow";
@@ -23,102 +23,6 @@ const HARDCODED_GAS_PRICE: Record<number, string> = {
   69: "15000000", // optimism
 };
 
-class MetaTx {
-  constructor(
-    public readonly nonce: number,
-    public readonly timestamp: number,
-    public readonly response: providers.TransactionResponse,
-    public readonly validated: boolean,
-  ) {}
-
-  public validate = () => {
-
-  }
-}
-
-/**
- * @classdesc Will wrap a stack of transaction info and handle all serialized operation on submit and confirm side.
- * 
- * 
- */
-class TransactionBuffer {
-  // Both of the following are functionally treated as stacks (LIFO).
-  private completed: MetaTx[] = []
-  private pending: MetaTx[] = []
-  // Should be used to access either of the stacks.
-  private readonly accessQueue: PriorityQueue = new PriorityQueue({ concurrency: 1 });
-
-  constructor(private readonly logger: BaseLogger, private readonly signer: Signer) {}
-
-  public push(nonce: number, response: providers.TransactionResponse) {
-    const timestamp = Date.now();
-    // Use the access queue to push.
-    this.accessQueue.add(() => {
-      this.pending.push(
-        {
-          nonce,
-          timestamp,
-          response,
-          validated: false,
-          
-        }
-      );
-    });
-  }
-
-  // So the expected behavior here is that, if the top transaction takes too long (needs to be bumped), we indicate a timeout occurred and
-  // then resubmit with bumped price.
-
-  // private async push(meta: MetaTx) {
-  private async confirmThread() {
-    while (true) {
-      if (this.pending.length > 0) {
-        // We want to confirm the first tx, and then go through the remaining list and see if they should be flagged to be bumped.
-        const meta = this.pending[0];
-        // First check the timestamp to see if this transaction has expired.
-        
-
-        // Next, 
-      } else {
-        // wait 1s
-        delay(1000);
-      }
-    }
-  }
-
-  
-  /**
-   * Get the current nonce value for our signer.
-   *
-   * @remarks
-   * Caller should still be prepared to get the incorrect nonce back. For instance,
-   * if the provider that just handled our sent tx has suddenly gone offline, this
-   * method may give the wrong nonce. This can be solved by making additional calls to
-   * submit the tx.
-   *
-   * @returns A number value for the current nonce.
-   *
-   * @throws RpcError if we fail to get transaction count from all providers.
-   */
-  public async getNonce(): Promise<number> {
-    // Update nonce value to greatest of all nonce values retrieved.
-    const nonce = (await this.getLastTx())?.nonce ?? await this.signer.getTransactionCount("pending");
-    return nonce;
-  }
-
-  private async getLastTx(): Promise<MetaTx | null> {
-    return await this.accessQueue.add(() => {
-      if (this.pending.length > 0) {
-        return this.pending[this.pending.length - 1];
-      } else if (this.completed.length > 0) {
-        return this.completed[this.completed.length - 1];
-      }
-      return null;
-    });
-  }
-
-}
-
 // TODO: #145 Manage the security of our transactions in the event of a reorg. Possibly raise quorum value,
 // implement a lookback, etc.
 
@@ -139,8 +43,6 @@ export class ChainRpcProvider {
 
   public readonly confirmationsRequired: number;
   public readonly confirmationTimeout: number;
-
-  private transactionBuffer: TransactionBuffer;
 
   /**
    * A class for managing the usage of an ethers FallbackProvider, and for wrapping calls in
@@ -206,7 +108,6 @@ export class ChainRpcProvider {
 
     // TODO: #146 We may ought to do this instantiation in the txservice constructor.
     this.signer = typeof signer === "string" ? new Wallet(signer, this.provider) : signer.connect(this.provider);
-    this.transactionBuffer = new TransactionBuffer(logger, this.signer);
   }
 
   /**
@@ -426,6 +327,17 @@ export class ChainRpcProvider {
         }
       }
       throw new UnpredictableGasLimit({ errors });
+    });
+  }
+
+  /**
+   * Gets the current pending transaction count.
+   *
+   * @returns Number of transactions sent, including pending transactions.
+   */
+   public getTransactionCount(): ResultAsync<number, TransactionError> {
+    return this.resultWrapper<number>(async () => {
+      return await this.signer.getTransactionCount("pending");
     });
   }
 

--- a/packages/txservice/src/transaction.ts
+++ b/packages/txservice/src/transaction.ts
@@ -13,11 +13,57 @@ import { AlreadyMined, TransactionReplaced, TransactionReverted, TransactionServ
 export class Transaction {
   // We use a unique ID to internally track a transaction through logs.
   public id: string = getUuid();
+  // Response that was accepted on-chain (this reference will be used in the event that replacements are made).
+  private response: providers.TransactionResponse | null = null;
   // Responses, in the order of attempts made for this tx.
   public responses: providers.TransactionResponse[] = [];
   // Receipt that we received for the on-chain transaction that was mined with
   // the desired number of confirmations.
   public receipt?: providers.TransactionReceipt;
+
+  // TODO: private setter
+  // Timestamp initially set on creation, but will be updated each time submit() is called.
+  public timestamp: number = Date.now();
+
+  // This error will be set in the instance of a failure.
+  private _error: Error | null = null;
+  public get error(): Error | null {
+    return this._error;
+  }
+
+  // Which transaction attempt we are on.
+  private _attempt = 0;
+  /**
+   * Getter to return the internal attempt
+   * @returns The attempt # of the transction
+   */
+  public get attempt(): number {
+    return this._attempt;
+  }
+
+  // Whether this transaction has been validated (received at least 1 confirmation).
+  // This flag will be flipped once validate() is called and validation is successful.
+  private _validated = false;
+  public get validated(): boolean {
+    return this._validated;
+  }
+
+  /**
+   * Specifies whether the transaction has been submitted.
+   * @returns boolean indicating whether the transaction is submitted.
+   */
+  public get didSubmit(): boolean {
+    return this.responses.length > 0;
+  }
+
+  /**
+   * Specifies whether the transaction has been completed - meaning that it's been
+   * mined and has received the target number of confirmations.
+   * @returns boolean indicating whether the transaction is completed.
+   */
+  public get didFinish(): boolean {
+    return !!this.receipt && this.receipt.confirmations >= this.provider.confirmationsRequired;
+  }
 
   /**
    * Retrieves all data needed to format a full transaction, including current gas price set, nonce, etc.
@@ -31,120 +77,30 @@ export class Transaction {
     };
   }
 
-  // Internal nonce tracking.
-  private _nonce?: number;
-  public get nonce(): number | undefined {
-    return this._nonce;
-  }
-  private set nonce(value: number | undefined) {
-    if (value == null) {
-      throw new TypeError(`Cannot set nonce to ${value}.`);
-    } else if (typeof this._nonce !== "undefined") {
-      if (value === this._nonce) {
-        // Safely return: the value passed in is the same as the current nonce.
-        // This has the added affect of having this setter perform as a validator.
-        return;
-      }
-      // For some reason, the nonce changed. Log this occurance as a critical failure.
-      this.logger.error(
-        {
-          currentNonce: this.nonce,
-          responseNonce: value,
-          transactionId: this.id,
-        },
-        "Attempt made to overwrite nonce!",
-      );
-      throw new TransactionServiceFailure(
-        "Cannot overwrite already existing nonce value; nonce may only be set once per transaction!",
-      );
-    }
-    this._nonce = value;
-  }
-
-  // Which transaction attempt we are on.
-  private _attempt = 0;
-  /**
-   * Getter to return the internal attempt
-   *
-   * @returns The _attempt of the transction
-   */
-  public get attempt(): number {
-    return this._attempt;
-  }
-
   /**
    * A data structure used for management of the lifecycle of one on-chain transaction.
    *
    * @param logger The pino.BaseLogger instance we use for logging.
    * @param provider The ChainRpcProvider instance we use for interfacing with the chain.
    * @param minTx The minimum transaction data required to send a transaction.
-   * @param config The overall shared config of TransactionService.
+   * @param nonce Assigned nonce number for this transaction.
+   * @param gasPrice The GasPrice tracker instance.
    */
-  private constructor(
+  constructor(
     private readonly logger: BaseLogger,
     private readonly provider: ChainRpcProvider,
-    private readonly minTx: WriteTransaction,
-    private readonly config: TransactionServiceConfig,
-    private readonly gasPrice: GasPrice,
-  ) {}
-
-  /**
-   * Static constructor method to generate a transaction instance, as it requires some
-   * async operations. Stubbed in unit tests in order to solely test the interface.
-   *
-   * @param logger The pino.BaseLogger instance we use for logging.
-   * @param provider The ChainRpcProvider instance we use for interfacing with the chain.
-   * @param tx The minimum transaction data required to send a transaction.
-   * @param config The overall shared config of TransactionService.
-   */
-  static async create(
-    logger: BaseLogger,
-    provider: ChainRpcProvider,
-    tx: WriteTransaction,
-    config: TransactionServiceConfig,
-  ): Promise<Transaction> {
-    let gasLimit: BigNumber;
-    let result = await provider.estimateGas(tx);
-    if (result.isErr()) {
-      if (result.error instanceof TransactionReverted) {
-        throw result.error;
-      }
-      logger.warn(
-        {
-          method: Transaction.create.name,
-          transaction: tx,
-          error: result.error,
-        },
-        "Estimate gas failed due to an unexpected error.",
-      );
-      throw result.error;
-    } else {
-      gasLimit = result.value;
-    }
-
-    result = await provider.getGasPrice();
-    if (result.isErr()) {
-      throw result.error;
-    }
-    const gasPrice = new GasPrice(result.value, gasLimit);
-    return new Transaction(logger, provider, tx, config, gasPrice);
-  }
-
-  /**
-   * Specifies whether the transaction has been submitted.
-   * @returns boolean indicating whether the transaction is submitted.
-   */
-  public didSubmit(): boolean {
-    return this.responses.length > 0;
-  }
-
-  /**
-   * Specifies whether the transaction has been completed - meaning that it's been
-   * mined and has received the target number of confirmations.
-   * @returns boolean indicating whether the transaction is completed.
-   */
-  public didFinish(): boolean {
-    return !!this.receipt && this.receipt.confirmations >= this.provider.confirmationsRequired;
+    public readonly minTx: WriteTransaction,
+    public readonly nonce: number,
+    public readonly gasPrice: GasPrice,
+  ) {
+    this.logger.debug(
+      {
+        id: this.id,
+        data: this.data,
+        timestamp: this.timestamp,
+      },
+      "New transaction created.",
+    );
   }
 
   /**
@@ -158,21 +114,24 @@ export class Transaction {
     // Check to make sure that, if this is a replacement tx, the replacement gas is higher.
     if (this.responses.length > 0) {
       // NOTE: There *should* always be a gasPrice in every response, but it is
-      // defined as optional. Handle that case :(
+      // defined as optional. Handle that case?
       // If there isn't a lastPrice, we're going to skip this validation step.
       const lastPrice = this.responses[this.responses.length - 1].gasPrice;
       if (lastPrice && this.gasPrice.get().lte(lastPrice)) {
+        // NOTE: We do not set this._error here, as the transaction hasn't failed - just the txservice.
         throw new TransactionServiceFailure("Gas price was not incremented from last transaction.", { method });
       }
     }
 
     // Check to make sure we haven't already mined this transaction.
-    if (this.didFinish()) {
+    if (this.didFinish) {
+      // NOTE: We do not set this._error here, as the transaction hasn't failed - just the txservice.
       throw new TransactionServiceFailure("Submit was called but transaction is already completed.", { method });
     }
 
     // Increment transaction attempts made.
     this._attempt++;
+    this.timestamp = Date.now();
 
     // Send the tx.
     let result = await this.provider.sendTransaction(this.data);
@@ -180,13 +139,14 @@ export class Transaction {
     // If the error is a NonceExpired error and we haven't submitted yet, we want to keep
     // trying to send here. Reason being that it may take a few tries to get the correct
     // transaction count back from the provider.
-    if (!this.didSubmit()) {
+    if (!this.didSubmit) {
       let nonceErrorCount = 0;
       while (
         result.isErr() &&
         result.error instanceof AlreadyMined &&
         result.error.reason === AlreadyMined.reasons.NonceExpired &&
-        nonceErrorCount < this.config.maxNonceErrorCount
+        // TODO: Hardcoded maxNonceErrorCount
+        nonceErrorCount < 10
       ) {
         nonceErrorCount++;
         this.logger.warn({ id: this.id, nonceErrorCount }, "Received nonce expired error.");
@@ -196,18 +156,115 @@ export class Transaction {
 
     // If we end up with a different error, it should be thrown here.
     if (result.isErr()) {
+      this._error = result.error;
       throw result.error;
     }
 
     const response = result.value;
 
-    // Save nonce if applicable; if not, this is a validation step to ensure nonce
-    // remains the same.
-    this.nonce = response.nonce;
-
     // Add this response to our local response history.
     this.responses.push(response);
     return response;
+  }
+
+  public async validate() {
+    const method = this.validate.name;
+
+    // Ensure we've submitted at least 1 tx.
+    if (!this.didSubmit) {
+      throw new TransactionServiceFailure("Transaction validate was called, but no transaction has been sent.", {
+        method,
+        id: this.id,
+      });
+    }
+
+    // Ensure we don't already have a receipt.
+    if (this.receipt != null) {
+      throw new TransactionServiceFailure("Transaction validate was called, but we already have receipt.", {
+        method,
+        id: this.id,
+      });
+    }
+
+    // Now we attempt to confirm the first response among our attempts. If it fails due to replacement,
+    // we'll get back the replacement's receipt from confirmTransaction.
+    this.response = this.response ?? this.responses[0];
+
+    // Get receipt for tx with at least 1 confirmation. If it times out (using default, configured timeout),
+    // it will throw a TransactionTimeout error.
+    const result = await this.provider.confirmTransaction(this.response, 1, this.timeUntilExpiry());
+    if (result.isErr()) {
+      this._error = result.error;
+      if (this._error instanceof TransactionReplaced) {
+        // TODO: #150 Should we handle error.reason?:
+        // error.reason - a string reason; one of "repriced", "cancelled" or "replaced"
+        // error.receipt - the receipt of the replacement transaction (a TransactionReceipt)
+        this.receipt = this._error.receipt;
+        // error.replacement - the replacement transaction (a TransactionResponse)
+        this.response = this._error.replacement;
+        this._validated = true;
+      } else if (this._error instanceof TransactionReverted) {
+        // NOTE: This is the official receipt with status of 0, so it's safe to say the
+        // transaction was in fact reverted and we should throw here.
+        this.receipt = this._error.receipt;
+        this._validated = true;
+        throw this._error;
+      } else {
+        throw this._error;
+      }
+    } else {
+      this.receipt = result.value;
+      this._validated = true;
+      // Sanity checks.
+      if (this.receipt == null) {
+        // Receipt is undefined or null. This normally should never occur.
+        throw new TransactionServiceFailure("Unable to obtain receipt: ethers responded with null.", {
+          method,
+          receipt: this.receipt,
+          hash: this.response.hash,
+          id: this.id,
+        });
+      } else if (this.receipt.status === 0) {
+        // This should never occur. We should always get a TransactionReverted error in this event.
+        throw new TransactionServiceFailure("Transaction was reverted but TransactionReverted error was not thrown.", {
+          method,
+          receipt: this.receipt,
+          hash: this.response.hash,
+          id: this.id,
+        });
+      } else if (this.receipt.confirmations < 1) {
+        // Again, should never occur.
+        throw new TransactionServiceFailure("Receipt did not have any confirmations, should have timed out!", {
+          method,
+          receipt: this.receipt,
+          hash: this.response.hash,
+          id: this.id,
+        });
+      }
+    }
+  }
+
+  /**
+   * Bump the gas price for this tx up by the configured percentage.
+   */
+  public bumpGasPrice() {
+    const currentPrice = this.gasPrice.get();
+    // Scale up gas by percentage as specified by config.
+    const bumpedGasPrice = currentPrice.add(currentPrice.mul(this.config.gasReplacementBumpPercent).div(100)).add(1);
+    this.gasPrice.set(bumpedGasPrice);
+    this.logger.info(
+      {
+        method: this.bumpGasPrice.name,
+        previousGasPrice: currentPrice.toString(),
+        newGasPrice: bumpedGasPrice.toString(),
+      },
+      "Bumping tx gas price for reattempt.",
+    );
+  }
+
+  private timeUntilExpiry(): number {
+    const expiry = this.timestamp + this.provider.confirmationTimeout;
+    return expiry - Date.now();
   }
 
   /**
@@ -228,76 +285,24 @@ export class Transaction {
     const method = this.confirm.name;
 
     // Ensure we've submitted at least 1 tx.
-    if (!this.didSubmit()) {
+    if (!this.didSubmit) {
       throw new TransactionServiceFailure("Transaction confirm was called, but no transaction has been sent.", {
         method,
         id: this.id,
       });
     }
 
-    // Ensure we don't already have a receipt.
-    if (this.receipt != null) {
-      throw new TransactionServiceFailure("Transaction confirm was called, but we already have receipt.", {
+    // Ensure we've been validated.
+    if (!this.validated || this.receipt == null || this.response == null) {
+      throw new TransactionServiceFailure("Transaction confirm was called, but transaction has not been validated.", {
         method,
+        receipt: this.receipt ? this.receipt.transactionHash : null,
+        response: this.response ? this.response.hash : null,
         id: this.id,
       });
     }
 
-    // Now we attempt to confirm the first response among our attempts. If it fails due to replacement,
-    // we'll get back the replacement's receipt from confirmTransaction.
-    let response = this.responses[0];
-
-    // Get receipt for tx with at least 1 confirmation. If it times out (using default, configured timeout),
-    // it will throw a TransactionTimeout error.
-    const result = await this.provider.confirmTransaction(response, 1);
-    if (result.isErr()) {
-      const { error } = result;
-      if (error instanceof TransactionReplaced) {
-        // TODO: #150 Should we handle error.reason?:
-        // error.reason - a string reason; one of "repriced", "cancelled" or "replaced"
-        // error.receipt - the receipt of the replacement transaction (a TransactionReceipt)
-        this.receipt = error.receipt;
-        // error.replacement - the replacement transaction (a TransactionResponse)
-        response = error.replacement;
-      } else if (error instanceof TransactionReverted) {
-        // NOTE: This is the official receipt with status of 0, so it's safe to say the
-        // transaction was in fact reverted and we should throw here.
-        this.receipt = error.receipt;
-        throw error;
-      } else {
-        throw error;
-      }
-    } else {
-      this.receipt = result.value;
-    }
-
-    // Sanity checks.
-    if (this.receipt == null) {
-      // Receipt is undefined or null. This normally should never occur.
-      throw new TransactionServiceFailure("Unable to obtain receipt: ethers responded with null.", {
-        method,
-        receipt: this.receipt,
-        hash: response.hash,
-        id: this.id,
-      });
-    } else if (this.receipt.status === 0) {
-      // This should never occur. We should always get a TransactionReverted error in this event.
-      throw new TransactionServiceFailure("Transaction was reverted but TransactionReverted error was not thrown.", {
-        method,
-        receipt: this.receipt,
-        hash: response.hash,
-        id: this.id,
-      });
-    } else if (this.receipt.confirmations < 1) {
-      // Again, should never occur.
-      throw new TransactionServiceFailure("Receipt did not have any confirmations, should have timed out!", {
-        method,
-        receipt: this.receipt,
-        hash: response.hash,
-        id: this.id,
-      });
-    }
-
+    const response = this.response;
     if (this.receipt.confirmations < this.provider.confirmationsRequired) {
       // Now we'll wait (up until an absurd amount of time) to receive all confirmations needed.
       // TODO: #151 Maybe set timeout to confirmationsRequired * confirmationTimeout...?
@@ -316,23 +321,5 @@ export class Transaction {
     }
 
     return this.receipt;
-  }
-
-  /**
-   * Bump the gas price for this tx up by the configured percentage.
-   */
-  public bumpGasPrice() {
-    const currentPrice = this.gasPrice.get();
-    // Scale up gas by percentage as specified by config.
-    const bumpedGasPrice = currentPrice.add(currentPrice.mul(this.config.gasReplacementBumpPercent).div(100)).add(1);
-    this.gasPrice.set(bumpedGasPrice);
-    this.logger.info(
-      {
-        method: this.bumpGasPrice.name,
-        previousGasPrice: currentPrice.toString(),
-        newGasPrice: bumpedGasPrice.toString(),
-      },
-      "Bumping tx gas price for reattempt.",
-    );
   }
 }


### PR DESCRIPTION
- Handle TODOs
- Make a backfill fn for a bunk tx (TODO should mark this)
- Handle dispatch vs provider antipattern. There's two maps in txservice and it's not pretty. We may want to remodel dispatch to either extend ChainRpcProvider or just move all the ChainRpcProvider functionality over here.
- Unit test fixes (make sure you close out any antipatterns first)
- Lots of load testing