### PR TITLE
Sdk already active

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,15 @@ The above command runs local chains and messaging and take care of local deploym
       "providers": ["http://localhost:8545"],
       "confirmations": 1,
       "subgraph": "http://localhost:8010/subgraphs/name/connext/nxtp",
-      "transactionManagerAddress": "0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0"
+      "transactionManagerAddress": "0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0",
+      "safeRelayerFee": 100
     },
     "1338": {
       "providers": ["http://localhost:8546"],
       "confirmations": 1,
       "subgraph": "http://localhost:9010/subgraphs/name/connext/nxtp",
-      "transactionManagerAddress": "0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0"
+      "transactionManagerAddress": "0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0",
+      "safeRelayerFee": 100
     }
   },
   "logLevel": "info",

--- a/packages/sdk/src/subgraph.ts
+++ b/packages/sdk/src/subgraph.ts
@@ -9,6 +9,7 @@ import {
   ReceiverTransactionCancelledPayload,
   ReceiverTransactionFulfilledPayload,
   ReceiverTransactionPreparedPayload,
+  SenderTransactionCancelledPayload,
   SenderTransactionPreparedPayload,
 } from "./sdk";
 import { getSdk, Sdk, TransactionStatus } from "./graphqlsdk";
@@ -55,6 +56,7 @@ export const convertTransactionToTxData = (transaction: any): TransactionData =>
 
 export const SubgraphEvents = {
   SenderTransactionPrepared: "SenderTransactionPrepared",
+  SenderTransactionCancelled: "SenderTransactionCancelled",
   ReceiverTransactionPrepared: "ReceiverTransactionPrepared",
   ReceiverTransactionFulfilled: "ReceiverTransactionFulfilled",
   ReceiverTransactionCancelled: "ReceiverTransactionCancelled",
@@ -63,6 +65,7 @@ export type SubgraphEvent = typeof SubgraphEvents[keyof typeof SubgraphEvents];
 
 export interface SubgraphEventPayloads {
   [SubgraphEvents.SenderTransactionPrepared]: SenderTransactionPreparedPayload;
+  [SubgraphEvents.SenderTransactionCancelled]: SenderTransactionCancelledPayload;
   [SubgraphEvents.ReceiverTransactionPrepared]: ReceiverTransactionPreparedPayload;
   [SubgraphEvents.ReceiverTransactionFulfilled]: ReceiverTransactionFulfilledPayload;
   [SubgraphEvents.ReceiverTransactionCancelled]: ReceiverTransactionCancelledPayload;
@@ -77,6 +80,7 @@ export const createSubgraphEvts = (): {
 } => {
   return {
     [SubgraphEvents.SenderTransactionPrepared]: Evt.create<SenderTransactionPreparedPayload>(),
+    [SubgraphEvents.SenderTransactionCancelled]: Evt.create<SenderTransactionCancelledPayload>(),
     [SubgraphEvents.ReceiverTransactionPrepared]: Evt.create<ReceiverTransactionPreparedPayload>(),
     [SubgraphEvents.ReceiverTransactionFulfilled]: Evt.create<ReceiverTransactionFulfilledPayload>(),
     [SubgraphEvents.ReceiverTransactionCancelled]: Evt.create<ReceiverTransactionCancelledPayload>(),
@@ -139,7 +143,133 @@ export class Subgraph {
   async getActiveTransactions(): Promise<ActiveTransaction[]> {
     const methodName = "getActiveTransactions";
     const methodId = getUuid();
+    console.log("starting getActiveTransactions");
 
+    // Step 1: handle any already listed as active transactions.
+    // This is important to make sure the events are properly emitted
+    // when sdks remain online for the duration of the transaction.
+    // i.e. consider the case the sender tx is fulfilled before the loop
+    // begins again. then it would not be captured by the subgraph only
+    // loop but would exist in the class memory
+
+    // Get all ids organized in an object with keyed on their receiving chain id
+    const idsBySendingChains: Record<string, string[]> = {};
+    [...this.activeTxs.entries()].forEach(([id, tx]) => {
+      if (!idsBySendingChains[tx.crosschainTx.invariant.sendingChainId]) {
+        idsBySendingChains[tx.crosschainTx.invariant.sendingChainId] = [id];
+      } else {
+        idsBySendingChains[tx.crosschainTx.invariant.sendingChainId].push(id);
+      }
+    });
+
+    // Gather matching sending-chain records from the subgraph that will *not*
+    // be handled by step 2 (i.e. statuses are *not* prepared)
+    const nonPreparedSendingTxs: any[] = [];
+    const correspondingReceiverTxIdsByChain: Record<string, string[]> = {};
+    await Promise.all(
+      Object.keys(idsBySendingChains).map(async (sendingChain) => {
+        const sendingSubgraph = this.sdks[parseInt(sendingChain)];
+        if (!sendingSubgraph) {
+          return;
+        }
+        const ids = idsBySendingChains[sendingChain];
+        if (ids.length === 0) {
+          return;
+        }
+        const { transactions } = await sendingSubgraph.GetTransactions({ transactionIds: ids });
+        if (transactions.length === 0) {
+          return;
+        }
+
+        // Get transactions to add
+        const toAdd = transactions.filter((x) => !!x && x.status !== TransactionStatus.Prepared);
+
+        // Add results to sending tx array
+        nonPreparedSendingTxs.push(...toAdd);
+      }),
+    );
+
+    // Get corresponding receiver transaction records
+    nonPreparedSendingTxs.forEach((transaction) => {
+      if (!correspondingReceiverTxIdsByChain[transaction.receivingChainId]) {
+        correspondingReceiverTxIdsByChain[transaction.receivingChainId] = [transaction.transactionId];
+      } else {
+        correspondingReceiverTxIdsByChain[transaction.receivingChainId].push(transaction.transactionId);
+      }
+    });
+
+    const correspondingReceiverTxs: any[] = [];
+    await Promise.all(
+      Object.keys(correspondingReceiverTxIdsByChain).map(async (receivingChain) => {
+        const subgraph = this.sdks[parseInt(receivingChain)];
+        if (!subgraph) {
+          return;
+        }
+        const ids = correspondingReceiverTxIdsByChain[receivingChain];
+        if (ids.length === 0) {
+          return;
+        }
+        const { transactions } = await subgraph.GetTransactions({ transactionIds: ids });
+        if (transactions.length === 0) {
+          return;
+        }
+
+        // Get transactions to add
+        const toAdd = transactions.filter((x) => !!x);
+
+        // Add results to sending tx array
+        correspondingReceiverTxs.push(...toAdd);
+      }),
+    );
+
+    // For all non-prepared sending transactions, post to the correct evt
+    // and update the transaction map
+    nonPreparedSendingTxs.map((transaction) => {
+      const record = this.activeTxs.get(transaction.transactionId)!;
+      const receivingMatches = correspondingReceiverTxs.filter((x) => x.transactionId === transaction.transactionId);
+      if (receivingMatches.length > 1) {
+        throw new Error("Duplicate transaction ids");
+      }
+      const [match] = receivingMatches;
+      if (transaction.status === TransactionStatus.Cancelled) {
+        // Remove from active transactions
+        this.activeTxs.delete(transaction.transactionId);
+
+        // Post data to evt
+        const { invariant, sending } = record.crosschainTx;
+        this.evts.SenderTransactionCancelled.post({
+          txData: { ...invariant, ...sending },
+          caller: transaction.cancelCaller,
+          transactionHash: transaction.cancelTransactionHash,
+        });
+        return;
+      }
+
+      if (transaction.status === TransactionStatus.Fulfilled) {
+        // Remove from active transactions
+        this.activeTxs.delete(transaction.transactionId);
+
+        // Find the matching receiver subgraph tx
+        if (!match || match.status !== TransactionStatus.Fulfilled) {
+          // This should never happen
+          throw new Error("Sender fulfilled, no fulfilled receiver transaction");
+        }
+
+        // Post to receiver transaction fulfilled evt
+        const { invariant, receiving } = record.crosschainTx;
+        this.evts.ReceiverTransactionFulfilled.post({
+          transactionHash: match.fulfillTranssactionHash,
+          txData: { ...invariant, ...receiving! },
+          signature: match.signature,
+          relayerFee: match.relayerFee,
+          callData: match.callData,
+          caller: match.fulfillCaller,
+        });
+      }
+    });
+
+    // Step 2: handle any not-listed active transactions (i.e. sdk has
+    // gone offline at some point during the transactions)
     const txs = await Promise.all(
       Object.keys(this.sdks).map(async (c) => {
         const user = (await this.user.getAddress()).toLowerCase();
@@ -168,14 +298,13 @@ export class Subgraph {
           Object.entries(senderPerChain).map(async ([chainId, senderTxs]) => {
             const _sdk = this.sdks[parseInt(chainId)];
             if (!_sdk) {
-              this.logger.error({ methodId, methodName, chainId }, "No SDK for chainId");
               return undefined;
             }
             const { transactions: correspondingReceiverTxs } = await _sdk.GetTransactions({
               transactionIds: senderTxs.map((tx) => tx.transactionId),
             });
 
-            return senderTxs.map((senderTx): ActiveTransaction | undefined => {
+            const active = senderTxs.map((senderTx): ActiveTransaction | undefined => {
               const correspondingReceiverTx = correspondingReceiverTxs.find(
                 (tx) => tx.transactionId === senderTx.transactionId,
               );
@@ -303,6 +432,8 @@ export class Subgraph {
                 correspondingReceiverTx,
               );
             });
+
+            return active;
           }),
         );
 

--- a/packages/sdk/src/subgraph.ts
+++ b/packages/sdk/src/subgraph.ts
@@ -143,7 +143,6 @@ export class Subgraph {
   async getActiveTransactions(): Promise<ActiveTransaction[]> {
     const methodName = "getActiveTransactions";
     const methodId = getUuid();
-    console.log("starting getActiveTransactions");
 
     // Step 1: handle any already listed as active transactions.
     // This is important to make sure the events are properly emitted

--- a/packages/utils/src/transactionManager.ts
+++ b/packages/utils/src/transactionManager.ts
@@ -97,6 +97,5 @@ export type TransactionFulfilledEvent = {
 
 export type TransactionCancelledEvent = {
   txData: TransactionData;
-  relayerFee: string;
   caller: string;
 };


### PR DESCRIPTION
Fixes bug where already tracked active transactions are not accounted for when handling active txs. 

This is the issue we are seeing in the intermittent CI failures