### PR TITLE
add option to pass in gas station to config

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -53,6 +53,7 @@ export const TChainConfig = Type.Object({
   subgraph: Type.String(),
   transactionManagerAddress: Type.String(),
   minGas: Type.String(),
+  gasStations: Type.Array(Type.String()),
   safeRelayerFee: Type.String(),
   subgraphSyncBuffer: Type.Number({ minimum: 1 }), // If subgraph is out of sync by this number, will not process actions
 });
@@ -95,7 +96,7 @@ export type NxtpRouterConfig = Static<typeof NxtpRouterConfigSchema>;
  *
  * @returns The router config with sensible defaults
  */
-export const getEnvConfig = (chainData: Map<string, any> | undefined): NxtpRouterConfig => {
+export const getEnvConfig = (crossChainData: Map<string, any> | undefined): NxtpRouterConfig => {
   let configJson: Record<string, any> = {};
   let configFile: any = {};
 
@@ -165,18 +166,24 @@ export const getEnvConfig = (chainData: Map<string, any> | undefined): NxtpRoute
   };
 
   const overridechainRecommendedConfirmations = configFile.overridechainRecommendedConfirmations;
-  if (!chainData && chainData!.size == 0 && !overridechainRecommendedConfirmations) {
+  if (!crossChainData && crossChainData!.size == 0 && !overridechainRecommendedConfirmations) {
     throw new Error(
       "Router configuration failed: no chain data provided. (To override, see `overridechainRecommendedConfirmations` in config. Overriding this behavior is not recommended.)",
     );
   }
-  const defaultConfirmations = chainData && chainData.has("1") ? parseInt(chainData.get("1").confirmations) + 3 : 4;
+  const defaultConfirmations =
+    crossChainData && crossChainData.has("1") ? parseInt(crossChainData.get("1").confirmations) + 3 : 4;
   // add contract deployments if they exist
   Object.entries(nxtpConfig.chainConfig).forEach(([chainId, chainConfig]) => {
+    const chainRecommendedConfirmations =
+      crossChainData && crossChainData.has(chainId)
+        ? parseInt(crossChainData.get(chainId).confirmations)
+        : defaultConfirmations;
+    const chainRecommendedGasStations =
+      crossChainData && crossChainData.has(chainId) ? crossChainData.get(chainId).gasStations ?? [] : [];
+
     // allow passed in address to override
     // format: { [chainId]: { [chainName]: { "contracts": { "TransactionManager": { "address": "...." } } } }
-    const chainRecommendedConfirmations =
-      chainData && chainData.has(chainId) ? parseInt(chainData.get(chainId).confirmations) : defaultConfirmations;
     if (!chainConfig.transactionManagerAddress) {
       const res = getDeployedTransactionManagerContract(parseInt(chainId));
       if (!res) {
@@ -184,12 +191,15 @@ export const getEnvConfig = (chainData: Map<string, any> | undefined): NxtpRoute
       }
       nxtpConfig.chainConfig[chainId].transactionManagerAddress = res.address;
     }
+
     if (!chainConfig.minGas) {
       nxtpConfig.chainConfig[chainId].minGas = MIN_GAS.toString();
     }
+
     if (!chainConfig.safeRelayerFee) {
       nxtpConfig.chainConfig[chainId].safeRelayerFee = MIN_RELAYER_FEE.toString();
     }
+
     if (!chainConfig.subgraph) {
       const subgraph = getDeployedSubgraphUri(Number(chainId));
       if (!subgraph) {
@@ -207,6 +217,9 @@ export const getEnvConfig = (chainData: Map<string, any> | undefined): NxtpRoute
       nxtpConfig.chainConfig[chainId].subgraphSyncBuffer =
         syncBuffer * 3 > MIN_SUBGRAPH_SYNC_BUFFER ? syncBuffer * 3 : MIN_SUBGRAPH_SYNC_BUFFER; // 25 blocks min
     }
+
+    const addedStations = nxtpConfig.chainConfig[chainId].gasStations ?? [];
+    nxtpConfig.chainConfig[chainId].gasStations = addedStations.concat(chainRecommendedGasStations);
 
     // Validate that confirmations is above acceptable/recommended minimum.
     const confirmations = chainConfig.confirmations ?? chainRecommendedConfirmations;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -53,6 +53,7 @@ export const makeRouter = async () => {
       chains[chainId] = {
         confirmations: config.confirmations,
         providers: config.providers.map((url) => ({ url })),
+        gasStations: config.gasStations,
       } as ChainConfig;
     });
     // TODO: txserviceconfig log level

--- a/packages/txservice/src/config.ts
+++ b/packages/txservice/src/config.ts
@@ -71,7 +71,7 @@ export const ChainConfigSchema = Type.Object({
   // Gas station URL, if any, to retrieve current gas price from. If gas station is down or otherwise fails,
   // we'll use the RPC provider's gas as a backup.
   // Gas station should return a "rapid" gas price within the response.data. See ethereum gasnow API as example.
-  gasStation: Type.Optional(Type.String()),
+  gasStations: Type.Array(Type.String()),
 
   // The amount of time (ms) to wait before a confirmation polling period times out,
   // indicating we should resubmit tx with higher gas if the tx is not confirmed.

--- a/packages/txservice/src/config.ts
+++ b/packages/txservice/src/config.ts
@@ -68,6 +68,10 @@ export const ChainConfigSchema = Type.Object({
   // Hardcoded initial value for gas. This shouldn't be used normally - only temporarily
   // in the event that a gas station is malfunctioning.
   defaultInitialGas: Type.Optional(TIntegerString),
+  // Gas station URL, if any, to retrieve current gas price from. If gas station is down or otherwise fails,
+  // we'll use the RPC provider's gas as a backup.
+  // Gas station should return a "rapid" gas price within the response.data. See ethereum gasnow API as example.
+  gasStation: Type.Optional(Type.String()),
 
   // The amount of time (ms) to wait before a confirmation polling period times out,
   // indicating we should resubmit tx with higher gas if the tx is not confirmed.

--- a/packages/txservice/src/dispatch/provider.ts
+++ b/packages/txservice/src/dispatch/provider.ts
@@ -254,13 +254,17 @@ export class ChainRpcProvider {
       const { gasInitialBumpPercent, gasMinimum } = this.config;
       let gasPrice: BigNumber | undefined = undefined;
 
-      if (this.chainId === 1) {
+      if (this.chainConfig.gasStation) {
+        const gasStation = this.chainId === 1 ? `https://www.gasnow.org/api/v3/gas/price` : this.chainConfig.gasStation;
         try {
-          const gasNowResponse = await axios.get(`https://www.gasnow.org/api/v3/gas/price`);
+          const gasNowResponse = await axios.get(gasStation);
           const { rapid } = gasNowResponse.data;
-          gasPrice = typeof rapid !== "undefined" ? BigNumber.from(rapid) : undefined;
+          gasPrice = rapid !== undefined ? BigNumber.from(rapid) : undefined;
         } catch (e) {
-          this.logger.warn("Gasnow failed, using provider", requestContext, methodContext, { error: jsonifyError(e) });
+          this.logger.warn("Gas station failed, using provider", requestContext, methodContext, {
+            gasStation,
+            error: jsonifyError(e),
+          });
         }
       }
 

--- a/packages/txservice/src/dispatch/provider.ts
+++ b/packages/txservice/src/dispatch/provider.ts
@@ -277,7 +277,6 @@ export class ChainRpcProvider {
       if (gasStations.length > 0 && gasPrice === undefined) {
         this.logger.warn("Gas stations failed, using provider call instead", requestContext, methodContext, {
           gasStations,
-          error: jsonifyError(e),
         });
       }
 

--- a/packages/utils/src/chainData.ts
+++ b/packages/utils/src/chainData.ts
@@ -26,7 +26,7 @@ export type ChainData = {
   rpc: string[];
   faucets: string[];
   infoURL: string;
-  gasStations?: string[];
+  gasStations: string[];
   explorers: {
     name: string;
     url: string;

--- a/packages/utils/src/chainData.ts
+++ b/packages/utils/src/chainData.ts
@@ -26,6 +26,7 @@ export type ChainData = {
   rpc: string[];
   faucets: string[];
   infoURL: string;
+  gasStations?: string[];
   explorers: {
     name: string;
     url: string;


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During high traffic (ergo high gas price) periods, getGasPrice is lagging and not reflective of the current "rapid" gas price. This results in tx's getting stuck for long periods bumping gas continually (up to 10 times before failing), all while the actual gas price domain (e.g. in the 300s gwei) is 3 or 4 multiples higher than the price domain we're in (eg 20-40 gwei).

## The Solution

getGasPrice should check to see if there's a configured gas station, and then grab the gas price from there. If the gas station fails / doesn't work, then we resort to relying on the RPC getGasPrice.

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->


sort of relies on : https://github.com/connext/chaindata/pull/31
## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
