### PR TITLE
Nonce expired

### DIFF
--- a/packages/txservice/src/dispatch/transaction.ts
+++ b/packages/txservice/src/dispatch/transaction.ts
@@ -31,7 +31,7 @@ export interface TransactionInterface {
   submit(): Promise<providers.TransactionResponse>;
   validate(): Promise<void>;
   confirm(): Promise<providers.TransactionReceipt>;
-  bumpGasPrice(): void;
+  bumpGasPrice(): Promise<void>;
 }
 
 /**

--- a/packages/txservice/src/dispatch/transaction.ts
+++ b/packages/txservice/src/dispatch/transaction.ts
@@ -1,4 +1,4 @@
-import { providers, BigNumber } from "ethers";
+import { providers, BigNumber, utils } from "ethers";
 import { createLoggingContext, delay, getUuid, Logger, RequestContext } from "@connext/nxtp-utils";
 
 import { DEFAULT_CONFIG } from "../config";
@@ -364,26 +364,28 @@ export class Transaction implements TransactionInterface {
     if (this.attempt >= MAX_ATTEMPTS) {
       // TODO: Log more info?
       throw new TransactionServiceFailure(TransactionServiceFailure.reasons.MaxAttemptsReached, {
-        gasPrice: this.gas.price.toString(),
+        gasPrice: `${utils.formatUnits(this.gas.price, "wei")} wei`,
         attempts: this.attempt,
       });
     }
     const previousPrice = this.gas.price;
     // Get the current gas baseline price, in case it's changed drastically in the last block.
     const result = await this.provider.getGasPrice(requestContext);
-    const baselinePrice = result.isOk() ? result.value : BigNumber.from(0);
-    const targetPrice = baselinePrice.gt(previousPrice) ? baselinePrice : previousPrice;
+    const updatedPrice = result.isOk() ? result.value : BigNumber.from(0);
+    const determinedBaseline = updatedPrice.gt(previousPrice) ? updatedPrice : previousPrice;
     // Scale up gas by percentage as specified by config.
     // TODO: Replace with actual config.
-    this.gas.price = targetPrice.add(targetPrice.mul(DEFAULT_CONFIG.gasReplacementBumpPercent).div(100)).add(1);
+    this.gas.price = determinedBaseline
+      .add(determinedBaseline.mul(DEFAULT_CONFIG.gasReplacementBumpPercent).div(100))
+      .add(1);
     this.logger.info(`Bumping tx gas price for reattempt.`, requestContext, methodContext, {
       chainId: this.chainId,
       id: this.id,
       attempt: this.attempt,
-      baselinePrice: baselinePrice.toString(),
-      targetPrice: targetPrice.toString(),
-      previousGasPrice: previousPrice.toString(),
-      newGasPrice: this.gas.price.toString(),
+      updatedPrice: `${utils.formatUnits(updatedPrice, "wei")} wei`,
+      previousPrice: `${utils.formatUnits(previousPrice, "wei")} wei`,
+      determinedBaseline: `${utils.formatUnits(determinedBaseline, "wei")} wei`,
+      newGasPrice: `${utils.formatUnits(this.gas.price, "wei")} wei`,
     });
   }
 

--- a/packages/txservice/src/error.ts
+++ b/packages/txservice/src/error.ts
@@ -212,11 +212,11 @@ export class TransactionServiceFailure extends NxtpError {
      */
     NotEnoughConfirmations: "Never reached the required amount of confirmations. Did a reorg occur?",
     /**
-     * MaxGasPriceReached: Indicates that the transaction bumped gas endlessly, and was never
+     * MaxAttemptsReached: Indicates that the transaction bumped gas endlessly, and was never
      * accepted by the chain (0 confirmations, and chain did not revert). Typically indicates on RPC
      * failure but could imply a failure in TransactionService to submit correctly to chain.
      */
-    MaxAttemptsReached: "Gas price went over configured limit.",
+    MaxAttemptsReached: "Reached maximum attempts.",
     GasEstimateInvalid: "The gas estimate returned was an invalid value.",
   };
 

--- a/packages/txservice/src/txservice.ts
+++ b/packages/txservice/src/txservice.ts
@@ -167,9 +167,6 @@ export class TransactionService {
           );
           if (error.type === TimeoutError.type) {
             // Transaction timed out trying to validate. We should bump the tx and submit again.
-            this.logger.debug(`Bumping transaction gas price for resubmit.`, requestContext, methodContext, {
-              id: transaction.id,
-            });
             await transaction.bumpGasPrice();
             continue;
           } else {

--- a/packages/txservice/src/txservice.ts
+++ b/packages/txservice/src/txservice.ts
@@ -135,8 +135,8 @@ export class TransactionService {
           });
           if (error.type === AlreadyMined.type) {
             if (transaction.attempt === 1) {
-              // Something is not working right - we should never encounter this expired nonce situation this many times.
               if (nonceExpired > 1000) {
+                // Nonce expired emergency stop: we should never encounter this expired nonce situation this many times.
                 this.logger.warn(`Nonce expired encountered > MAX (1000)`, requestContext, methodContext, {
                   id: transaction.id,
                   attempt: transaction.attempt,

--- a/packages/txservice/src/txservice.ts
+++ b/packages/txservice/src/txservice.ts
@@ -118,7 +118,7 @@ export class TransactionService {
       tx: { ...tx, value: tx.value.toString(), data: `${tx.data.substring(0, 9)}...` },
     });
 
-    const newTx = async () => await this.getProvider(tx.chainId).createTransaction(tx, requestContext);
+    const newTx = () => this.getProvider(tx.chainId).createTransaction(tx, requestContext);
 
     let transaction = await newTx();
     try {


### PR DESCRIPTION
## The Problem

Getting nonce expired errors due to edge case described in comment here:
```ts
          if (error.type === AlreadyMined.type) {
            if (transaction.attempt === 1) {
              // A transaction that's only been attempted once has an expired nonce. This means that dispatch
              // assigned us an already-used nonce.

              // In this event, we need to go back to the beginning and actually "recreate" the transaction
              // itself now. Assuming our nonce tracker (dispatch) is effective, this should normally never occur...
              // but there is at least 1 legit edge case: if the dispatch has just come online, it can only rely on
              // the provider's tx count (getTransactionCount) to assign nonce - and the provider turns out to be
              // incorrect (e.g. off by 1 or 2 pending tx's not in its mempool yet for some reason).
              transaction = await newTx();
              continue;
            }
          ...
```

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

See above code - we basically just create a new tx within the block and wrap back around to beginning of the loop. If the nonce is properly expired / already used, we should just keep looping until its locally incremented to the correct value.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
