### PR TITLE
Use proper default if not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [txservice] Properly handle insufficient funds errors
 - [router] Log gas when there is low balance
+- [router] Properly default signature on admin cancel endpoint
 
 ## 0.0.48
 

--- a/packages/router/src/bindings/fastify/index.ts
+++ b/packages/router/src/bindings/fastify/index.ts
@@ -74,7 +74,7 @@ export const bindFastify = () =>
           const senderTx = await prepareCancel({ senderChainId, user, transactionId });
           const result = await contractWriter.cancel(
             senderTx.txData.sendingChainId,
-            { signature: senderTx.signature!, txData: senderTx.txData },
+            { signature: senderTx.signature ?? "0x", txData: senderTx.txData },
             requestContext,
           );
           return { transactionHash: result.transactionHash };


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Admin cancel endpoint doesn't work without a signature on sender side (which router may not have or need)

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Default `null` signature to empty signature of `0x`

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
