### PR TITLE
[router] Hotfix: prevent error in active tx retrieval from blocking other chains

### DIFF
--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -107,212 +107,229 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
 
   // get local context
   const sdks = getSdks();
+  const errors: Map<string, Error> = new Map();
   const allChains = await Promise.all(
     Object.entries(sdks).map(async ([cId, sdk]) => {
-      const chainId = parseInt(cId);
+      try {
+        const chainId = parseInt(cId);
 
-      const chainConfig = config.chainConfig[chainId];
-      if (!chainConfig) {
-        throw new NoChainConfig(chainId);
-      }
-
-      const allReceiverExpired = await sdk.GetReceiverTransactions({
-        routerId: routerAddress.toLowerCase(),
-        receivingChainId: chainId,
-        status: SdkTransactionStatus.Prepared,
-        expiry_lt: Math.floor(Date.now() / 1000),
-      });
-
-      logger.debug("Got receiver expired", requestContext, methodContext, {
-        chainId,
-        allReceiverExpired: jsonifyError(allReceiverExpired as any),
-      });
-
-      // get all sender prepared txs
-      const allSenderPrepared = await sdk.GetSenderTransactions({
-        routerId: routerAddress.toLowerCase(),
-        sendingChainId: chainId,
-        status: SdkTransactionStatus.Prepared,
-      });
-
-      // check synced status
-      const record = await setSyncRecord(chainId, requestContext);
-      logger.debug("Got sync record", requestContext, methodContext, { chainId, record });
-
-      // create list of txIds for each receiving chain
-      const receivingChains: Record<string, string[]> = {};
-      const toCancel: any[] = []; // i hate these types!!
-      allSenderPrepared.router?.transactions.forEach((senderTx) => {
-        const _sdk = sdks[Number(senderTx.receivingChainId)];
-        if (!_sdk) {
-          // if receiving SDK doesnt exist, cancel all the txs
-          logger.warn(
-            "No contract reader available for receiver chain, marking sender tx for cancellation",
-            { ...requestContext, transactionId: senderTx.transactionId } as RequestContext<string>,
-            methodContext,
-            { sendingChain: senderTx.chainId, receivingChain: senderTx.receivingChainId },
-          );
-          toCancel.push(senderTx);
+        const chainConfig = config.chainConfig[chainId];
+        if (!chainConfig) {
+          throw new NoChainConfig(chainId);
         }
-        if (receivingChains[senderTx.receivingChainId]) {
-          receivingChains[senderTx.receivingChainId].push(senderTx.transactionId);
-        } else {
-          receivingChains[senderTx.receivingChainId] = [senderTx.transactionId];
-        }
-      });
 
-      const receiverNotConfigured = toCancel.map((senderTx) => {
-        return {
-          crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
-          payload: {},
-          status: CrosschainTransactionStatus.ReceiverNotConfigured,
-        } as ActiveTransaction<"ReceiverNotConfigured">;
-      });
+        const allReceiverExpired = await sdk.GetReceiverTransactions({
+          routerId: routerAddress.toLowerCase(),
+          receivingChainId: chainId,
+          status: SdkTransactionStatus.Prepared,
+          expiry_lt: Math.floor(Date.now() / 1000),
+        });
 
-      // get time to use for loop
-      const currentTime = await getNtpTimeSeconds();
+        logger.debug("Got receiver expired", requestContext, methodContext, {
+          chainId,
+          allReceiverExpired: jsonifyError(allReceiverExpired as any),
+        });
 
-      // get all existing txs corresponding to all the sender prepared txs by id
-      let allSenderPreparedTx = allSenderPrepared.router?.transactions ?? [];
-      const queries = await Promise.all(
-        Object.entries(receivingChains).map(async ([cId, txIds]) => {
-          const _sdk = sdks[Number(cId)];
+        // get all sender prepared txs
+        const allSenderPrepared = await sdk.GetSenderTransactions({
+          routerId: routerAddress.toLowerCase(),
+          sendingChainId: chainId,
+          status: SdkTransactionStatus.Prepared,
+        });
+
+        // check synced status
+        const record = await setSyncRecord(chainId, requestContext);
+        logger.debug("Got sync record", requestContext, methodContext, { chainId, record });
+
+        // create list of txIds for each receiving chain
+        const receivingChains: Record<string, string[]> = {};
+        const toCancel: any[] = []; // i hate these types!!
+        allSenderPrepared.router?.transactions.forEach((senderTx) => {
+          const _sdk = sdks[Number(senderTx.receivingChainId)];
           if (!_sdk) {
+            // if receiving SDK doesnt exist, cancel all the txs
             logger.warn(
-              "No contract reader available for receiver chain, filtering txs",
-              requestContext,
+              "No contract reader available for receiver chain, marking sender tx for cancellation",
+              { ...requestContext, transactionId: senderTx.transactionId } as RequestContext<string>,
               methodContext,
-              { receivingChain: cId },
+              { sendingChain: senderTx.chainId, receivingChain: senderTx.receivingChainId },
             );
-            // filter all txs where no contract reader on receiver side and not expired yet
-            // if its expired on sender side, we can still cancel it, it will be marked for cancellation later
-            allSenderPreparedTx = allSenderPreparedTx.filter(
-              (tx) => tx.receivingChainId !== cId && currentTime > tx.expiry,
-            );
-            return [];
+            toCancel.push(senderTx);
           }
-          const query = await _sdk.GetTransactions({ transactionIds: txIds.map((t) => t.toLowerCase()) });
-          return query.transactions;
-        }),
-      );
-      const correspondingReceiverTxs = queries.flat();
-
-      allReceiverExpired.router?.transactions.forEach((receiverTx) => {
-        const tx = correspondingReceiverTxs.find((tx) => tx.transactionId === receiverTx.transactionId);
-        if (tx) {
-          return;
-        }
-        correspondingReceiverTxs.push(receiverTx);
-      });
-
-      // foreach sender prepared check if corresponding receiver exists
-      // if it does not, call the handleSenderPrepare handler
-      // if it is fulfilled, call the handleReceiverFulfill handler
-      // if it is cancelled, call the handlerReceiverCancel handler
-      const txs =
-        allSenderPreparedTx.map((senderTx): ActiveTransaction<any> | undefined => {
-          const { invariant, sending } = sdkSenderTransactionToCrosschainTransaction(senderTx);
-
-          const correspondingReceiverTx = correspondingReceiverTxs.find(
-            (receiverTx) => senderTx.transactionId === receiverTx.transactionId,
-          );
-
-          const receiving: VariantTransactionData | undefined = correspondingReceiverTx
-            ? {
-                amount: correspondingReceiverTx.amount,
-                expiry: Number(correspondingReceiverTx.expiry),
-                preparedBlockNumber: Number(correspondingReceiverTx.preparedBlockNumber),
-              }
-            : undefined;
-
-          if (currentTime > senderTx.expiry) {
-            // sender expired takes precedence over receiver expired
-            return {
-              crosschainTx: {
-                invariant,
-                sending,
-                receiving,
-              },
-              payload: {},
-              status: CrosschainTransactionStatus.SenderExpired,
-            } as ActiveTransaction<"SenderExpired">;
+          if (receivingChains[senderTx.receivingChainId]) {
+            receivingChains[senderTx.receivingChainId].push(senderTx.transactionId);
+          } else {
+            receivingChains[senderTx.receivingChainId] = [senderTx.transactionId];
           }
+        });
 
-          if (!receiving) {
-            // if not synced, cancel
-            const receiverSynced = getSyncRecord(invariant.receivingChainId);
-            if (!receiverSynced) {
-              return {
-                crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
-                payload: {},
-                status: CrosschainTransactionStatus.ReceiverNotConfigured,
-              } as ActiveTransaction<"ReceiverNotConfigured">;
+        const receiverNotConfigured = toCancel.map((senderTx) => {
+          return {
+            crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
+            payload: {},
+            status: CrosschainTransactionStatus.ReceiverNotConfigured,
+          } as ActiveTransaction<"ReceiverNotConfigured">;
+        });
+
+        // get time to use for loop
+        const currentTime = await getNtpTimeSeconds();
+
+        // get all existing txs corresponding to all the sender prepared txs by id
+        let allSenderPreparedTx = allSenderPrepared.router?.transactions ?? [];
+        const queries = await Promise.all(
+          Object.entries(receivingChains).map(async ([cId, txIds]) => {
+            const _sdk = sdks[Number(cId)];
+            if (!_sdk) {
+              logger.warn(
+                "No contract reader available for receiver chain, filtering txs",
+                requestContext,
+                methodContext,
+                { receivingChain: cId },
+              );
+              // filter all txs where no contract reader on receiver side and not expired yet
+              // if its expired on sender side, we can still cancel it, it will be marked for cancellation later
+              allSenderPreparedTx = allSenderPreparedTx.filter(
+                (tx) => tx.receivingChainId !== cId && currentTime > tx.expiry,
+              );
+              return [];
             }
-            // sender prepared
-            return {
-              crosschainTx: {
-                invariant,
-                sending,
-              },
-              payload: {
-                bidSignature: senderTx.bidSignature,
-                encodedBid: senderTx.encodedBid,
-                encryptedCallData: senderTx.encryptedCallData,
-                senderPreparedHash: senderTx.prepareTransactionHash,
-              },
-              status: CrosschainTransactionStatus.SenderPrepared,
-            } as ActiveTransaction<"SenderPrepared">;
-          }
+            const query = await _sdk.GetTransactions({ transactionIds: txIds.map((t) => t.toLowerCase()) });
+            return query.transactions;
+          }),
+        );
+        const correspondingReceiverTxs = queries.flat();
 
-          // we have a receiver tx at this point
-          // if expired, return
-          if (currentTime > receiving.expiry && correspondingReceiverTx!.status === SdkTransactionStatus.Prepared) {
-            return {
-              crosschainTx: {
-                invariant,
-                sending,
-                receiving,
-              },
-              payload: {},
-              status: CrosschainTransactionStatus.ReceiverExpired,
-            } as ActiveTransaction<"ReceiverExpired">;
+        allReceiverExpired.router?.transactions.forEach((receiverTx) => {
+          const tx = correspondingReceiverTxs.find((tx) => tx.transactionId === receiverTx.transactionId);
+          if (tx) {
+            return;
           }
+          correspondingReceiverTxs.push(receiverTx);
+        });
 
-          if (correspondingReceiverTx!.status === SdkTransactionStatus.Fulfilled) {
-            // receiver fulfilled
-            return {
-              crosschainTx: {
-                invariant,
-                sending,
-                receiving,
-              },
-              payload: {
-                signature: correspondingReceiverTx!.signature,
-                relayerFee: correspondingReceiverTx!.relayerFee,
-                callData: correspondingReceiverTx!.callData!,
-                receiverFulfilledHash: correspondingReceiverTx!.fulfillTransactionHash,
-              },
-              status: CrosschainTransactionStatus.ReceiverFulfilled,
-            } as ActiveTransaction<"ReceiverFulfilled">;
-          }
-          if (correspondingReceiverTx!.status === SdkTransactionStatus.Cancelled) {
-            // receiver cancelled
-            return {
-              crosschainTx: {
-                invariant,
-                sending,
-                receiving,
-              },
-              payload: {} as CancelPayload,
-              status: CrosschainTransactionStatus.ReceiverCancelled,
-            };
-          }
-          return undefined;
-        }) ?? [];
-      const filterUndefined = txs.filter((x) => !!x) as ActiveTransaction<any>[];
-      return filterUndefined.concat(receiverNotConfigured);
+        // foreach sender prepared check if corresponding receiver exists
+        // if it does not, call the handleSenderPrepare handler
+        // if it is fulfilled, call the handleReceiverFulfill handler
+        // if it is cancelled, call the handlerReceiverCancel handler
+        const txs =
+          allSenderPreparedTx.map((senderTx): ActiveTransaction<any> | undefined => {
+            const { invariant, sending } = sdkSenderTransactionToCrosschainTransaction(senderTx);
+
+            const correspondingReceiverTx = correspondingReceiverTxs.find(
+              (receiverTx) => senderTx.transactionId === receiverTx.transactionId,
+            );
+
+            const receiving: VariantTransactionData | undefined = correspondingReceiverTx
+              ? {
+                  amount: correspondingReceiverTx.amount,
+                  expiry: Number(correspondingReceiverTx.expiry),
+                  preparedBlockNumber: Number(correspondingReceiverTx.preparedBlockNumber),
+                }
+              : undefined;
+
+            if (currentTime > senderTx.expiry) {
+              // sender expired takes precedence over receiver expired
+              return {
+                crosschainTx: {
+                  invariant,
+                  sending,
+                  receiving,
+                },
+                payload: {},
+                status: CrosschainTransactionStatus.SenderExpired,
+              } as ActiveTransaction<"SenderExpired">;
+            }
+
+            if (!receiving) {
+              // if not synced, cancel
+              const receiverSynced = getSyncRecord(invariant.receivingChainId);
+              if (!receiverSynced) {
+                return {
+                  crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
+                  payload: {},
+                  status: CrosschainTransactionStatus.ReceiverNotConfigured,
+                } as ActiveTransaction<"ReceiverNotConfigured">;
+              }
+              // sender prepared
+              return {
+                crosschainTx: {
+                  invariant,
+                  sending,
+                },
+                payload: {
+                  bidSignature: senderTx.bidSignature,
+                  encodedBid: senderTx.encodedBid,
+                  encryptedCallData: senderTx.encryptedCallData,
+                  senderPreparedHash: senderTx.prepareTransactionHash,
+                },
+                status: CrosschainTransactionStatus.SenderPrepared,
+              } as ActiveTransaction<"SenderPrepared">;
+            }
+
+            // we have a receiver tx at this point
+            // if expired, return
+            if (currentTime > receiving.expiry && correspondingReceiverTx!.status === SdkTransactionStatus.Prepared) {
+              return {
+                crosschainTx: {
+                  invariant,
+                  sending,
+                  receiving,
+                },
+                payload: {},
+                status: CrosschainTransactionStatus.ReceiverExpired,
+              } as ActiveTransaction<"ReceiverExpired">;
+            }
+
+            if (correspondingReceiverTx!.status === SdkTransactionStatus.Fulfilled) {
+              // receiver fulfilled
+              return {
+                crosschainTx: {
+                  invariant,
+                  sending,
+                  receiving,
+                },
+                payload: {
+                  signature: correspondingReceiverTx!.signature,
+                  relayerFee: correspondingReceiverTx!.relayerFee,
+                  callData: correspondingReceiverTx!.callData!,
+                  receiverFulfilledHash: correspondingReceiverTx!.fulfillTransactionHash,
+                },
+                status: CrosschainTransactionStatus.ReceiverFulfilled,
+              } as ActiveTransaction<"ReceiverFulfilled">;
+            }
+            if (correspondingReceiverTx!.status === SdkTransactionStatus.Cancelled) {
+              // receiver cancelled
+              return {
+                crosschainTx: {
+                  invariant,
+                  sending,
+                  receiving,
+                },
+                payload: {} as CancelPayload,
+                status: CrosschainTransactionStatus.ReceiverCancelled,
+              };
+            }
+            return undefined;
+          }) ?? [];
+        const filterUndefined = txs.filter((x) => !!x) as ActiveTransaction<any>[];
+        return filterUndefined.concat(receiverNotConfigured);
+      } catch (e) {
+        // Set this chain's error.
+        errors.set(cId, e);
+        logger.error(
+          `Error getting active transactions for chain ${cId}`,
+          requestContext,
+          methodContext,
+          jsonifyError(e),
+          { chainId: cId },
+        );
+        return [];
+      }
     }),
   );
+  if (errors.size === Object.keys(sdks).length) {
+    throw new Error("getActiveTransactions failed for all chains");
+  }
   const flattened = allChains.filter((x) => !!x).flat();
   return flattened;
 };


### PR DESCRIPTION
## The Problem
In `getActiveTransactions` in `packages/router/src/adapters/subgraph/subgraph.ts`,  if any one of the anonymous async methods to which we map in the `Promise.all` throws, then we will short circuit all other methods for all other chains. It will cause `getActiveTransactions` to throw the error - so we won't return anything.

## The Solution

I added a try/catch inside the anonymous methods in the mapping in the `Promise.all` block. We log the errors when they occur in the catch block, and put them in a `Map<string, Error>` object indexed by chainId. Currently I'm just using that `Map` to check whether the # errors that occurred === # chains we support; in which case, we throw the error.

This will enable us to continue supporting the working chains even when 1 chain is consistently failing for some reason.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
