### PR TITLE
Slightly modified the subgraph to be able to calculate the time taken for a swap

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -61,11 +61,13 @@ type Transaction @entity {
   fulfillCaller: Bytes
   fulfillTransactionHash: Bytes
   fulfillMeta: Bytes
+  fulfillTimestamp: BigInt
 
   # TransactionCancelled
   cancelCaller: Bytes
   cancelTransactionHash: Bytes
   cancelMeta: Bytes
+  cancelTimestamp: BigInt
 }
 
 # User entity keeps track of active user transactions

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -183,6 +183,7 @@ export function handleTransactionFulfilled(event: TransactionFulfilled): void {
   transaction!.fulfillCaller = event.params.caller;
   transaction!.fulfillTransactionHash = event.transaction.hash;
   transaction!.fulfillMeta = event.params.args.encodedMeta;
+  transaction!.fulfillTimestamp = event.block.timestamp;
 
   transaction!.save();
 
@@ -214,6 +215,7 @@ export function handleTransactionCancelled(event: TransactionCancelled): void {
   transaction!.cancelCaller = event.params.caller;
   transaction!.cancelTransactionHash = event.transaction.hash;
   transaction!.cancelMeta = event.params.args.encodedMeta;
+  transaction!.cancelTimestamp = event.block.timestamp;
 
   transaction!.save();
 


### PR DESCRIPTION
## The Problem

Currently, it's not possible to calculate the time taken for a swap using the current subgraphs because there is no timestamp for when the transaction is fulfilled. 
There's no timestamp for when the transaction is canceled either, this might be needed in the data analysis. 

## The Solution

Added fulfillTimestamp and cancelTimestamp to the schema. 
Mapped these two variables with the right data on mapping.ts 

## Checklist

- Deployed and tested with the Arbitrum contract. 