### PR TITLE
[sdk/router] fix fallback subgraph in-sync requirements

### DIFF
--- a/packages/router/src/adapters/subgraph/index.ts
+++ b/packages/router/src/adapters/subgraph/index.ts
@@ -7,7 +7,7 @@ import { ContractReaderNotAvailableForChain } from "../../lib/errors/contractRea
 import { getContext } from "../../router";
 
 import { getSdk, Sdk } from "./graphqlsdk";
-import { getActiveTransactions, getAssetBalance, getTransactionForChain, getSyncRecord } from "./subgraph";
+import { getActiveTransactions, getAssetBalance, getTransactionForChain, getSyncRecords } from "./subgraph";
 
 export type ContractReader = {
   getActiveTransactions: () => Promise<ActiveTransaction<any>[]>;
@@ -26,7 +26,7 @@ export type ContractReader = {
    * @returns The available balance
    */
   getAssetBalance: (assetId: string, chainId: number) => Promise<BigNumber>;
-  getSyncRecord: (chainId: number, requestContext?: RequestContext) => Promise<SubgraphSyncRecord[]>;
+  getSyncRecords: (chainId: number, requestContext?: RequestContext) => Promise<SubgraphSyncRecord[]>;
 };
 
 const sdks: Record<number, FallbackSubgraph<Sdk>> = {};
@@ -51,6 +51,6 @@ export const subgraphContractReader = (): ContractReader => {
     getActiveTransactions,
     getTransactionForChain,
     getAssetBalance,
-    getSyncRecord,
+    getSyncRecords,
   };
 };

--- a/packages/router/src/adapters/subgraph/index.ts
+++ b/packages/router/src/adapters/subgraph/index.ts
@@ -39,11 +39,11 @@ export const getSdks = (): Record<number, FallbackSubgraph<Sdk>> => {
 };
 
 export const subgraphContractReader = (): ContractReader => {
-  const { config, logger } = getContext();
+  const { config } = getContext();
   Object.entries(config.chainConfig).forEach(([chainId, { subgraph, subgraphSyncBuffer }]) => {
     const chainIdNumber = parseInt(chainId);
     const sdksWithClients = subgraph.map((uri) => ({ client: getSdk(new GraphQLClient(uri)), uri }));
-    const fallbackSubgraph = new FallbackSubgraph<Sdk>(logger, chainIdNumber, sdksWithClients, subgraphSyncBuffer);
+    const fallbackSubgraph = new FallbackSubgraph<Sdk>(chainIdNumber, sdksWithClients, subgraphSyncBuffer);
     sdks[chainIdNumber] = fallbackSubgraph;
   });
 

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -4,6 +4,7 @@ import {
   getNtpTimeSeconds,
   getUuid,
   jsonifyError,
+  NxtpError,
   RequestContext,
   SubgraphSyncRecord,
   VariantTransactionData,
@@ -334,11 +335,7 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
     }),
   );
   if (errors.size === Object.keys(sdks).length) {
-    if (errors.size === 1) {
-      // Just throw the first error in the Map if there's only one chain supported.
-      throw errors.values().next().value;
-    }
-    throw new Error("Failed to get active transactions for all chains");
+    throw new NxtpError("Failed to get active transactions for all chains due to errors", { errors });
   }
   const flattened = allChains.filter((x) => !!x).flat();
   return flattened;

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -31,16 +31,15 @@ import {
 
 import { getSdks } from ".";
 
-const synced: Record<number, SubgraphSyncRecord[]> = {};
-
-export const getSyncRecord = async (
+export const getSyncRecords = async (
   chainId: number,
   _requestContext?: RequestContext,
 ): Promise<SubgraphSyncRecord[]> => {
-  const { requestContext } = createLoggingContext(getSyncRecord.name, _requestContext);
+  const { requestContext } = createLoggingContext(getSyncRecords.name, _requestContext);
 
-  const records = synced[chainId];
-  return records ?? (await setSyncRecord(chainId, requestContext));
+  const sdks = getSdks();
+  const sdk = sdks[chainId];
+  return sdk.hasSynced ? sdk.records : await setSyncRecord(chainId, requestContext);
 };
 
 const setSyncRecord = async (chainId: number, requestContext: RequestContext): Promise<SubgraphSyncRecord[]> => {
@@ -249,7 +248,7 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
 
             if (!receiving) {
               // if not synced, cancel
-              const receiverSynced = getSyncRecord(invariant.receivingChainId);
+              const receiverSynced = getSyncRecords(invariant.receivingChainId);
               if (!receiverSynced) {
                 return {
                   crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),

--- a/packages/router/src/bindings/contractReader/index.ts
+++ b/packages/router/src/bindings/contractReader/index.ts
@@ -68,7 +68,7 @@ export const bindContractReader = async () => {
     // subgraph buffer
     // remove records only iff transaction handled mined block is synced with respective chain subgraph
     Object.entries(config.chainConfig).forEach(async ([chainId]) => {
-      const records = await contractReader.getSyncRecord(Number(chainId));
+      const records = await contractReader.getSyncRecords(Number(chainId));
       const highestSyncedBlock = Math.max(...records.map((r) => r.syncedBlock));
       handlingTracker.forEach((value, key) => {
       if (value.chainId === Number(chainId) && value.blockNumber != -1 && value.blockNumber <= highestSyncedBlock) {

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -94,7 +94,7 @@ export const TChainConfig = Type.Object({
   gasStations: Type.Array(Type.String()),
   allowFulfillRelay: Type.Boolean(),
   relayerFeeThreshold: Type.Number({ minimum: 0, maximum: 100 }),
-  subgraphSyncBuffer: Type.Number({ minimum: 1 }), // If subgraph is out of sync by this number, will not process actions
+  subgraphSyncBuffer: Type.Number({ minimum: MIN_SUBGRAPH_SYNC_BUFFER }), // If subgraph is out of sync by this number, will not process actions
 });
 
 export const TSwapPool = Type.Object({

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -94,7 +94,7 @@ export const TChainConfig = Type.Object({
   gasStations: Type.Array(Type.String()),
   allowFulfillRelay: Type.Boolean(),
   relayerFeeThreshold: Type.Number({ minimum: 0, maximum: 100 }),
-  subgraphSyncBuffer: Type.Number({ minimum: MIN_SUBGRAPH_SYNC_BUFFER }), // If subgraph is out of sync by this number, will not process actions
+  subgraphSyncBuffer: Type.Number(), // If subgraph is out of sync by this number, will not process actions
 });
 
 export const TSwapPool = Type.Object({
@@ -272,7 +272,7 @@ export const getEnvConfig = (crossChainData: Map<string, any> | undefined): Nxtp
       nxtpConfig.chainConfig[chainId].confirmations = chainRecommendedConfirmations;
     }
 
-    if (!chainConfig.subgraphSyncBuffer) {
+    if (!chainConfig.subgraphSyncBuffer || chainConfig.subgraphSyncBuffer <= 0) {
       const syncBuffer = (chainRecommendedConfirmations ?? 1) * 3;
       nxtpConfig.chainConfig[chainId].subgraphSyncBuffer =
         syncBuffer * 3 > MIN_SUBGRAPH_SYNC_BUFFER ? syncBuffer * 3 : MIN_SUBGRAPH_SYNC_BUFFER; // 25 blocks min

--- a/packages/router/src/lib/operations/auction.ts
+++ b/packages/router/src/lib/operations/auction.ts
@@ -154,7 +154,7 @@ export const newAuction = async (
   }
 
   // Make sure subgraphs are synced
-  const receivingSyncRecords = await contractReader.getSyncRecord(receivingChainId, requestContext);
+  const receivingSyncRecords = await contractReader.getSyncRecords(receivingChainId, requestContext);
   if (!receivingSyncRecords.some((record) => record.synced)) {
     throw new SubgraphNotSynced(receivingChainId, receivingSyncRecords, {
       methodContext,
@@ -163,7 +163,7 @@ export const newAuction = async (
     });
   }
 
-  const sendingSyncRecords = await contractReader.getSyncRecord(sendingChainId, requestContext);
+  const sendingSyncRecords = await contractReader.getSyncRecords(sendingChainId, requestContext);
   if (!sendingSyncRecords.some((record) => record.synced)) {
     throw new SubgraphNotSynced(sendingChainId, sendingSyncRecords, {
       methodContext,

--- a/packages/router/test/adapters/subgraph/subgraph.spec.ts
+++ b/packages/router/test/adapters/subgraph/subgraph.spec.ts
@@ -14,7 +14,7 @@ import { TransactionStatus } from "../../../src/adapters/subgraph/graphqlsdk";
 import {
   getActiveTransactions,
   getAssetBalance,
-  getSyncRecord,
+  getSyncRecords,
   getTransactionForChain,
   sdkSenderTransactionToCrosschainTransaction,
 } from "../../../src/adapters/subgraph/subgraph";
@@ -94,11 +94,11 @@ describe("Subgraph Adapter", () => {
     ctxMock.config = config;
   });
 
-  describe("#getSyncRecord", () => {
+  describe("#getSyncRecords", () => {
     it("should work", async () => {
       sdk.GetBlockNumber.resolves({ _meta: { block: { number: 10 } } });
       txServiceMock.getBlockNumber.resolves(10);
-      expect(await getSyncRecord(sendingChainId)).to.be.deep.eq([
+      expect(await getSyncRecords(sendingChainId)).to.be.deep.eq([
         {
           synced: true,
           syncedBlock: 10,
@@ -143,7 +143,7 @@ describe("Subgraph Adapter", () => {
       sdk.GetBlockNumber.resolves({ _meta: { block: { number: testSyncedBlockNumber } } });
       txServiceMock.getBlockNumber.resolves(testLatestBlockNumber);
       expect(await getActiveTransactions()).to.be.deep.eq([]);
-      expect(await getSyncRecord(sendingChainId)).to.be.deep.eq([
+      expect(await getSyncRecords(sendingChainId)).to.be.deep.eq([
         { synced: false, syncedBlock: 1, latestBlock: testLatestBlockNumber, lag: testLag, uri: "" },
       ]);
     });

--- a/packages/router/test/globalTestHook.ts
+++ b/packages/router/test/globalTestHook.ts
@@ -40,7 +40,7 @@ export const mochaHooks = {
       getActiveTransactions: stub().resolves([activeTransactionPrepareMock, activeTransactionFulfillMock]),
       getAssetBalance: stub().resolves(BigNumber.from("10001000000000000000000")),
       getTransactionForChain: stub().resolves(singleChainTransactionMock),
-      getSyncRecord: stub().returns([{ synced: true, syncedBlock: 10000, latestBlock: 10000, lag: 0, uri: "" }]),
+      getSyncRecords: stub().returns([{ synced: true, syncedBlock: 10000, latestBlock: 10000, lag: 0, uri: "" }]),
     };
 
     contractWriterMock = {

--- a/packages/router/test/lib/operations/auction.spec.ts
+++ b/packages/router/test/lib/operations/auction.spec.ts
@@ -75,7 +75,7 @@ describe("Auction Operation", () => {
 
     it("should error if sending subgraph is out of sync", async () => {
       const records = [{ synced: false, latestBlock: 0, syncedBlock: 0, uri: "", lag: 0 }];
-      (contractReaderMock.getSyncRecord as SinonStub).onCall(0).returns(records);
+      (contractReaderMock.getSyncRecords as SinonStub).onCall(0).returns(records);
       await expect(newAuction(auctionPayload, requestContext)).to.be.rejectedWith(
         SubgraphNotSynced.getMessage(auctionPayload.receivingChainId, records),
       );
@@ -83,7 +83,7 @@ describe("Auction Operation", () => {
 
     it("should error if receiving subgraph is out of sync", async () => {
       const records = [{ synced: false, latestBlock: 0, syncedBlock: 0, uri: "", lag: 0 }];
-      (contractReaderMock.getSyncRecord as SinonStub).onCall(1).returns(records);
+      (contractReaderMock.getSyncRecords as SinonStub).onCall(1).returns(records);
       await expect(newAuction(auctionPayload, requestContext)).to.be.rejectedWith(
         SubgraphNotSynced.getMessage(auctionPayload.sendingChainId, records),
       );

--- a/packages/sdk/src/subgraph/subgraph.ts
+++ b/packages/sdk/src/subgraph/subgraph.ts
@@ -171,7 +171,7 @@ export class Subgraph {
   }
 
   getSyncStatus(chainId: number): SubgraphSyncRecord {
-    const record = this.syncStatus[chainId];
+    const record = this.sdks[chainId].records[0];
     return (
       record ?? {
         synced: false,
@@ -241,7 +241,6 @@ export class Subgraph {
 
         const { transactions } = await subgraph.request<GetTransactionsQuery>((client) =>
           client.GetTransactions({ transactionIds: ids }),
-          false,
         );
         if (transactions.length === 0) {
           return;
@@ -567,7 +566,6 @@ export class Subgraph {
             userId: user,
             status: TransactionStatus.Fulfilled,
           }),
-          false,
         );
 
         // for each, break up receiving txs by chain
@@ -592,7 +590,6 @@ export class Subgraph {
               client.GetTransactions({
                 transactionIds: receiverTxs.map((tx) => tx.transactionId),
               }),
-              false,
             );
 
             return receiverTxs.map((receiverTx): HistoricalTransaction | undefined => {
@@ -663,7 +660,6 @@ export class Subgraph {
             userId: user,
             status: TransactionStatus.Cancelled,
           }),
-          false,
         );
 
         const cancelled = senderCancelled.map((tx): HistoricalTransaction | undefined => {

--- a/packages/sdk/src/subgraph/subgraph.ts
+++ b/packages/sdk/src/subgraph/subgraph.ts
@@ -127,7 +127,6 @@ export class Subgraph {
         const uris = typeof subgraph === "string" ? [subgraph] : subgraph;
         const sdksWithClients = uris.map((uri) => ({ client: getSdk(new GraphQLClient(uri)), uri }));
         const fallbackSubgraph = new FallbackSubgraph<Sdk>(
-          logger,
           cId,
           sdksWithClients,
           _subgraphSyncBuffer ?? DEFAULT_SUBGRAPH_SYNC_BUFFER,

--- a/packages/sdk/test/unit/subgraph.spec.ts
+++ b/packages/sdk/test/unit/subgraph.spec.ts
@@ -235,10 +235,16 @@ describe("Subgraph", () => {
             getMockTransaction({ transactionId }),
           ),
         );
+        const testError = new Error("test");
+        sdkStub.GetTransactions.onFirstCall().rejects(testError);
 
-        sdkStub.GetTransactions.onFirstCall().rejects(new Error("fail"));
+        try {
+          await subgraph.getActiveTransactions();
+        } catch (e) {
+          const expectedErrMessage = testError.message;
+          expect(e.context.errors.map((err) => err.message).includes(expectedErrMessage)).to.be.true;
+        }
 
-        await expect(subgraph.getActiveTransactions()).to.be.rejectedWith("fail");
         expect(sdkStub.GetTransactions.firstCall.args[0]).to.be.deep.eq({ transactionIds: [transactionId] });
       });
 
@@ -253,9 +259,16 @@ describe("Subgraph", () => {
         sdkStub.GetTransactions.onFirstCall().resolves({
           transactions: [subgraphSending],
         });
-        sdkStub.GetTransactions.onSecondCall().rejects(new Error("fail"));
+        const testError = new Error("test");
+        sdkStub.GetTransactions.onSecondCall().rejects(testError);
 
-        await expect(subgraph.getActiveTransactions()).to.be.rejectedWith("fail");
+        try {
+          await subgraph.getActiveTransactions();
+        } catch (e) {
+          const expectedErrMessage = testError.message;
+          expect(e.context.errors.map((err) => err.message).includes(expectedErrMessage)).to.be.true;
+        }
+
         expect(sdkStub.GetTransactions.firstCall.args[0]).to.be.deep.eq({ transactionIds: [transactionId] });
         expect(sdkStub.GetTransactions.secondCall.args[0]).to.be.deep.eq({ transactionIds: [transactionId] });
       });
@@ -631,22 +644,42 @@ describe("Subgraph", () => {
 
   describe("getHistoricalTransactions", async () => {
     it("should fail if GetReceiverTransactions fails", async () => {
-      sdkStub.GetReceiverTransactions.rejects(new Error("fail"));
+      const testError = new Error("test");
+      sdkStub.GetReceiverTransactions.rejects(testError);
 
-      await expect(subgraph.getHistoricalTransactions()).to.be.rejectedWith("fail");
+      try {
+        await subgraph.getActiveTransactions();
+      } catch (e) {
+        const expectedErrMessage = testError.message;
+        expect(e.context.errors.map((err) => err.message).includes(expectedErrMessage)).to.be.true;
+      }
     });
 
     it("should fail if GetTransactions fails", async () => {
       sdkStub.GetReceiverTransactions.resolves({ transactions: [transactionSubgraphMock] });
-      sdkStub.GetTransactions.rejects(new Error("fail"));
+      const testError = new Error("test");
+      sdkStub.GetTransactions.rejects(testError);
 
-      await expect(subgraph.getHistoricalTransactions()).to.be.rejectedWith("fail");
+      try {
+        await subgraph.getActiveTransactions();
+      } catch (e) {
+        const expectedErrMessage = testError.message;
+        expect(e.context.errors.map((err) => err.message).includes(expectedErrMessage)).to.be.true;
+      }
     });
 
     it("should fail if GetSenderTransactions fails", async () => {
-      sdkStub.GetSenderTransactions.rejects(new Error("fail"));
+      const testError = new Error("test");
+      sdkStub.GetSenderTransactions.rejects(testError);
 
-      await expect(subgraph.getHistoricalTransactions()).to.be.rejectedWith("fail");
+      try {
+        await subgraph.getActiveTransactions();
+      } catch (e) {
+        const expectedErrMessage = testError.message;
+        const chainErrors = e.context.errors;
+        const sendingChainErrors = chainErrors.get(sendingChainId).context.errors;
+        expect(sendingChainErrors.map((err) => err.message).includes(expectedErrMessage)).to.be.true;
+      }
     });
 
     it("should ignore transactions without matching sender side tx", async () => {

--- a/packages/utils/src/fallbackSubgraph.ts
+++ b/packages/utils/src/fallbackSubgraph.ts
@@ -129,7 +129,8 @@ export class FallbackSubgraph<T extends SdkLike> {
             } finally {
               sdk.metrics.calls.push({
                 timestamp: startTime,
-                execTime: Date.now() - startTime,
+                // Exec time is measured in seconds.
+                execTime: (Date.now() - startTime) / 1000,
                 success,
               });
             }

--- a/packages/utils/src/fallbackSubgraph.ts
+++ b/packages/utils/src/fallbackSubgraph.ts
@@ -142,7 +142,7 @@ export class FallbackSubgraph<T extends SdkLike> {
     const error = new NxtpError("Unable to handle request", { errors });
     this.logger.error("Error calling method on subgraph client(s).", undefined, methodContext, jsonifyError(error), {
       chainId: this.chainId,
-      otherErrors: errors,
+      errors,
     });
     throw error;
   }


### PR DESCRIPTION
## The Problem

Subgraph failing on one chain due to all the subgraph providers being out of sync is causing failure on all chains.

This seems to be occurring in the sdk, not in router - bc router's calls are all wrapped in try/catch per chain.

Error:
```
{"level":50,"time":1635867900140,"pid":1,"hostname":"80993d7e403d","name":"0x29A519e21d6A97cdB82270b69c98bAc6426CDCf9","requestContext":{"id":"st3wTsHgQ6e9OkZ2nP44LQ/7241201","origin":"getActiveTransactions"},"methodContext":{"id":"st3wTsHgQ6e9OkZ2nP44LQ/7241200","name":"getActiveTransactions"},"chainId":"250","error":{"message":"All subgraphs out of sync! Cannot handle active transactions for chain 56","type":"Error","context":{},"stack":"Error: All subgraphs out of sync! Cannot handle active transactions for chain 56\n    at FallbackSubgraph.request (/home/node/node_modules/@connext/nxtp-utils/dist/fallbackSubgraph.js:37:19)\n    at /home/node/router/dist/adapters/subgraph/subgraph.js:144:42\n    at Array.map (<anonymous>)\n    at /home/node/router/dist/adapters/subgraph/subgraph.js:135:79\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async Promise.all (index 3)\n    at async Object.getActiveTransactions (/home/node/router/dist/adapters/subgraph/subgraph.js:78:23)\n    at async Timeout._onTimeout (/home/node/router/dist/bindings/contractReader/index.js:21:28)"},"msg":"Error getting active transactions for chain 250"}
```

## The Solution

Some adjustments were made to some faulty bit of logic for fallback subg, as well as to the SDK and router logic.

No changes to CHANGELOG as this should be a part of fallback subg

## Checklist

- [x] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
