### PR TITLE
Fulfill response

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -78,6 +78,7 @@ const config: HardhatUserConfig = {
       accounts: { mnemonic },
       chainId: 1,
       url: urlOverride || process.env.ETH_PROVIDER_URL || "https://cloudflare-eth.com",
+      gasPrice: 10000000000,
     },
     ropsten: {
       accounts: { mnemonic },

--- a/packages/integration/test/integration.spec.ts
+++ b/packages/integration/test/integration.spec.ts
@@ -240,19 +240,10 @@ describe("Integration", () => {
       (data) => data.txData.transactionId === res.transactionId,
     );
 
-    const fulfillEventPromise = userSdk.waitFor(
-      NxtpSdkEvents.ReceiverTransactionFulfilled,
-      100_000,
-      (data) => data.txData.transactionId === res.transactionId,
-    );
-
-    const finishRes = await userSdk.fulfillTransfer(event, utils.parseEther("0.00001").toString());
+    const finishRes = await userSdk.fulfillTransfer(event, true);
     console.info("fullfill Transfer at receiver side", finishRes);
 
-    expect(finishRes.metaTxResponse).to.be.ok;
-    const fulfillEvent = await fulfillEventPromise;
-    console.info("fullfill Event", fulfillEvent);
-    expect(fulfillEvent).to.be.ok;
+    expect(finishRes.transactionHash).to.be.ok;
   };
 
   beforeEach(async () => {

--- a/packages/integration/test/integration.spec.ts
+++ b/packages/integration/test/integration.spec.ts
@@ -216,6 +216,7 @@ describe("Integration", () => {
   const test = async (sendingAssetId: string, receivingAssetId: string) => {
     let quote: AuctionResponse;
     try {
+      await userSdk.getActiveTransactions();
       quote = await userSdk.getTransferQuote({
         amount: utils.parseEther("1").toString(),
         receivingAssetId,

--- a/packages/sdk-server/src/index.ts
+++ b/packages/sdk-server/src/index.ts
@@ -121,7 +121,7 @@ server.post<{
     relayerFee?: string;
     useRelayers?: boolean;
   };
-  Reply: { fulfillRequest?: providers.TransactionRequest; metaTxResponse?: MetaTxResponse };
+  Reply: { transactionRequest?: providers.TransactionRequest; transactionResponse?: MetaTxResponse };
 }>(
   fulfillTransfer,
   {

--- a/packages/sdk/src/error.ts
+++ b/packages/sdk/src/error.ts
@@ -3,7 +3,6 @@ import {
   AuctionPayload,
   AuctionResponse,
   jsonifyError,
-  MetaTxPayload,
   NxtpError,
   NxtpErrorJson,
 } from "@connext/nxtp-utils";
@@ -353,33 +352,6 @@ export class UnknownAuctionError extends AuctionError {
 }
 
 /**
- * @classdesc Thrown when no responses to meta tx request in some timeframe
- */
-export class MetaTxTimeout extends RelayerError {
-  static getMessage(timeout: number) {
-    return `No relayer responses within ${timeout}ms`;
-  }
-
-  constructor(
-    public readonly transactionId: string,
-    public readonly timeout: number,
-    public readonly request: MetaTxPayload<any>,
-    public readonly context: any = {},
-  ) {
-    super(
-      MetaTxTimeout.getMessage(timeout),
-      {
-        transactionId,
-        timeout,
-        request,
-        ...context,
-      },
-      RelayerError.type,
-    );
-  }
-}
-
-/**
  * @classdesc Defines the error thrown by the `TransactionManager` class when a transaction fails to be submitted.
  */
 export class SubmitError extends TransactionManagerError {
@@ -467,6 +439,25 @@ export class SubgraphsNotSynced extends SubgraphError {
 }
 
 /**
+ * @classdesc Thrown when polling is not active
+ */
+export class PollingNotActive extends SubgraphError {
+  static getMessage() {
+    return `Subgraph polling not active`;
+  }
+
+  constructor(public readonly context: any = {}) {
+    super(
+      PollingNotActive.getMessage(),
+      {
+        ...context,
+      },
+      SubgraphError.type,
+    );
+  }
+}
+
+/**
  * @classdesc Thrown when subgraphs are not synced
  */
 export class RelayFailed extends FulfillError {
@@ -482,6 +473,32 @@ export class RelayFailed extends FulfillError {
     super(
       RelayFailed.getMessage(transactionId, chainId),
       {
+        ...context,
+      },
+      FulfillError.type,
+    );
+  }
+}
+
+/**
+ * @classdesc Thrown when no responses to meta tx request in some timeframe
+ */
+export class FulfillTimeout extends FulfillError {
+  static getMessage(timeout: number, chainId: number) {
+    return `No fulfill response responses within ${timeout}ms on chain ${chainId}`;
+  }
+
+  constructor(
+    public readonly transactionId: string,
+    public readonly timeout: number,
+    public readonly chainId: number,
+    public readonly context: any = {},
+  ) {
+    super(
+      FulfillTimeout.getMessage(timeout, chainId),
+      {
+        transactionId,
+        timeout,
         ...context,
       },
       FulfillError.type,

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -9,7 +9,6 @@ import {
   TransactionPreparedEvent,
   AuctionResponse,
   InvariantTransactionData,
-  MetaTxResponse,
   jsonifyError,
   isNode,
   NATS_AUTH_URL,
@@ -46,11 +45,10 @@ import {
   UnknownAuctionError,
   ChainNotConfigured,
   InvalidBidSignature,
-  MetaTxTimeout,
   SubgraphsNotSynced,
   NoPriceOracle,
   InvalidParamStructure,
-  RelayFailed,
+  FulfillTimeout,
 } from "./error";
 import {
   TransactionManager,
@@ -90,7 +88,7 @@ export const MIN_SLIPPAGE_TOLERANCE = "00.01"; // 0.01%;
 export const MAX_SLIPPAGE_TOLERANCE = "15.00"; // 15.0%
 export const DEFAULT_SLIPPAGE_TOLERANCE = "0.10"; // 0.10%
 export const DEFAULT_AUCTION_TIMEOUT = 6_000;
-export const META_TX_TIMEOUT = 300_000;
+export const FULFILL_TIMEOUT = 300_000;
 
 Evt.setDefaultMaxHandlers(250);
 
@@ -730,8 +728,10 @@ export class NxtpSdkBase {
     decryptedCallData: string,
     relayerFee = "0",
     useRelayers = true,
-    useGelatoRelay = false,
-  ): Promise<{ fulfillRequest?: providers.TransactionRequest; metaTxResponse?: MetaTxResponse }> {
+  ): Promise<{
+    transactionResponse?: { transactionHash: string; chainId: number };
+    transactionRequest?: providers.TransactionRequest;
+  }> {
     const { requestContext, methodContext } = createLoggingContext(
       this.fulfillTransfer.name,
       undefined,
@@ -765,74 +765,69 @@ export class NxtpSdkBase {
       throw new ChainNotConfigured(txData.receivingChainId, Object.keys(this.config.chainConfig));
     }
 
-    if (useGelatoRelay && isChainSupportedByGelato(txData.receivingChainId)) {
-      this.logger.info("Fulfilling using Gelato Relayer", requestContext, methodContext);
-      const deployedContract = this.config.chainConfig[txData.receivingChainId].transactionManagerAddress!;
-      const data = await gelatoFulfill(
-        txData.receivingChainId,
-        deployedContract,
-        new Interface(TransactionManagerAbi),
-        {
-          txData,
-          relayerFee,
-          signature: fulfillSignature,
-          callData: decryptedCallData,
-        },
-      );
-      this.logger.info("Method completed using Gelato Relayer", requestContext, methodContext, { taskId: data.taskId });
-
-      console.log("****** data: ", data);
-      if (!data.taskId) {
-        throw new RelayFailed(transactionId, txData.receivingChainId);
-      }
-
-      return {
-        metaTxResponse: { transactionHash: data.taskId, chainId: txData.receivingChainId },
-      };
-    }
+    const fulfillTxProm = this.waitFor(SubgraphEvents.ReceiverTransactionFulfilled, FULFILL_TIMEOUT, (data) => {
+      return data.txData.transactionId === params.txData.transactionId;
+    });
 
     if (useRelayers) {
-      this.logger.info("Fulfilling using relayers", requestContext, methodContext);
-      if (!this.messaging.isConnected()) {
-        await this.connectMessaging();
+      if (isChainSupportedByGelato(txData.receivingChainId)) {
+        this.logger.info("Fulfilling using Gelato Relayer", requestContext, methodContext);
+        const deployedContract = this.config.chainConfig[txData.receivingChainId].transactionManagerAddress!;
+        const data = await gelatoFulfill(
+          txData.receivingChainId,
+          deployedContract,
+          new Interface(TransactionManagerAbi),
+          {
+            txData,
+            relayerFee,
+            signature: fulfillSignature,
+            callData: decryptedCallData,
+          },
+        );
+        this.logger.info("Submitted using Gelato Relayer", requestContext, methodContext, { data });
+      } else {
+        this.logger.info("Fulfilling using relayers", requestContext, methodContext);
+        if (!this.messaging.isConnected()) {
+          await this.connectMessaging();
+        }
+
+        // send through messaging to metatx relayers
+        const responseInbox = generateMessagingInbox();
+
+        const request = {
+          type: MetaTxTypes.Fulfill,
+          relayerFee,
+          to: this.transactionManager.getTransactionManagerAddress(txData.receivingChainId)!,
+          chainId: txData.receivingChainId,
+          data: {
+            relayerFee,
+            signature: fulfillSignature,
+            txData,
+            callData: decryptedCallData,
+          },
+        };
+        await this.messaging.publishMetaTxRequest(request, responseInbox);
+        this.logger.info("Submitted using router network", requestContext, methodContext, { request });
       }
 
-      // send through messaging to metatx relayers
-      const responseInbox = generateMessagingInbox();
-
-      const metaTxProm = this.waitFor(SubgraphEvents.ReceiverTransactionFulfilled, META_TX_TIMEOUT, (data) => {
-        return data.txData.transactionId === params.txData.transactionId;
-      });
-
-      const request = {
-        type: MetaTxTypes.Fulfill,
-        relayerFee,
-        to: this.transactionManager.getTransactionManagerAddress(txData.receivingChainId)!,
-        chainId: txData.receivingChainId,
-        data: {
-          relayerFee,
-          signature: fulfillSignature,
-          txData,
-          callData: decryptedCallData,
-        },
-      };
-      await this.messaging.publishMetaTxRequest(request, responseInbox);
-
       try {
-        const response = await metaTxProm;
+        const response = await fulfillTxProm;
         const ret = {
           transactionHash: response.transactionHash,
           chainId: response.txData.receivingChainId,
         };
         this.logger.info("Method complete", requestContext, methodContext, ret);
-        return {
-          metaTxResponse: ret,
-        };
+        return { transactionResponse: ret };
       } catch (e) {
-        throw e.message.includes("Evt timeout") ? new MetaTxTimeout(txData.transactionId, META_TX_TIMEOUT, request) : e;
+        throw e.message.includes("Evt timeout")
+          ? new FulfillTimeout(txData.transactionId, FULFILL_TIMEOUT, params.txData.receivingChainId, {
+              requestContext,
+              methodContext,
+            })
+          : e;
       }
     } else {
-      this.logger.info("Fulfilling with user's signer", requestContext, methodContext);
+      this.logger.info("Creating transaction request", requestContext, methodContext);
       const fulfillRequest = await this.transactionManager.fulfill(
         txData.receivingChainId,
         {
@@ -845,7 +840,7 @@ export class NxtpSdkBase {
       );
 
       this.logger.info("Method complete", requestContext, methodContext, { fulfillRequest });
-      return { fulfillRequest };
+      return { transactionRequest: fulfillRequest };
     }
   }
 

--- a/packages/sdk/src/subgraph/subgraph.ts
+++ b/packages/sdk/src/subgraph/subgraph.ts
@@ -12,7 +12,7 @@ import {
 import { GraphQLClient } from "graphql-request";
 import { Evt } from "evt";
 
-import { InvalidTxStatus } from "../error";
+import { InvalidTxStatus, PollingNotActive } from "../error";
 import {
   SenderTransactionPreparedPayload,
   SenderTransactionCancelledPayload,
@@ -773,6 +773,9 @@ export class Subgraph {
     timeout: number,
     filter: (data: SubgraphEventPayloads[T]) => boolean = (_data: SubgraphEventPayloads[T]) => true,
   ): Promise<SubgraphEventPayloads[T]> {
+    if (!this.pollingLoop) {
+      throw new PollingNotActive();
+    }
     return this.evts[event].pipe(filter).waitFor(timeout) as Promise<SubgraphEventPayloads[T]>;
   }
 }

--- a/packages/utils/src/messaging.ts
+++ b/packages/utils/src/messaging.ts
@@ -85,7 +85,7 @@ export class NatsBasicMessagingService {
   private connection: INatsService | undefined;
   private log: Logger;
 
-  private authUrl?: string;
+  private authUrl: string;
   private bearerToken?: string;
   private natsUrl?: string;
   protected signer: Signer;
@@ -151,7 +151,7 @@ export class NatsBasicMessagingService {
     if (bearerToken) {
       this.bearerToken = bearerToken;
     } else if (!this.bearerToken) {
-      const token = await getBearerToken(this.authUrl!, this.signer)();
+      const token = await getBearerToken(this.authUrl, this.signer)();
       this.bearerToken = token;
     }
     // TODO: #155 fail fast w sensible error message if bearer token is invalid #446
@@ -205,6 +205,7 @@ export class NatsBasicMessagingService {
     this.assertConnected();
     const toPublish = safeJsonStringify(data);
     this.log.debug(`Publishing`, requestContext, methodContext, { subject, data });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     await this.connection!.publish(subject, toPublish);
   }
 
@@ -225,6 +226,7 @@ export class NatsBasicMessagingService {
     const { requestContext, methodContext } = createLoggingContext(this.request.name, _requestContext);
     this.assertConnected();
     this.log.debug(`Requesting`, requestContext, methodContext, { subject, data });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const response = await this.connection!.request(subject, timeout, JSON.stringify(data));
     this.log.debug(`Request returned`, requestContext, methodContext, { subject, response });
     return response;
@@ -243,6 +245,7 @@ export class NatsBasicMessagingService {
   ): Promise<void> {
     const { requestContext, methodContext } = createLoggingContext(this.subscribe.name, _requestContext);
     this.assertConnected();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     await this.connection!.subscribe(subject, (msg: any, err?: any): void => {
       const parsedMsg = typeof msg === `string` ? JSON.parse(msg) : msg;
       const parsedData = typeof msg.data === `string` ? JSON.parse(msg.data) : msg.data;
@@ -261,6 +264,7 @@ export class NatsBasicMessagingService {
     this.assertConnected();
     const unsubscribeFrom = this.getSubjectsToUnsubscribeFrom(subject);
     unsubscribeFrom.forEach((sub) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       this.connection!.unsubscribe(sub);
     });
   }
@@ -269,6 +273,7 @@ export class NatsBasicMessagingService {
    * Flushes the messaging connection
    */
   public async flush(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     await this.connection!.flush();
   }
 
@@ -281,6 +286,7 @@ export class NatsBasicMessagingService {
    */
   protected getSubjectsToUnsubscribeFrom(subject: string): string[] {
     // must account for wildcards
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const subscribedTo = this.connection!.getSubscribedSubjects();
     const unsubscribeFrom: string[] = [];
 
@@ -506,6 +512,7 @@ export class NatsNxtpMessagingService extends NatsBasicMessagingService {
           });
           return handler(from, "ERROR", msg?.data?.data, err);
         }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         return handler(from, msg.data.responseInbox!, msg?.data?.data, err);
       },
       requestContext,


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Gelato integration needed cleanup. Fixes #503 

## The Solution

Standardize fulfill response, default relayer to Gelato. Add retries to gelato.

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
