### PR TITLE
Added Arbitrum support using the Gelato Relayer

### DIFF
--- a/packages/utils/src/gelato.ts
+++ b/packages/utils/src/gelato.ts
@@ -11,6 +11,7 @@ const CHAIN_ID = {
   BSC: 56,
   MATIC: 137,
   FANTOM: 250,
+  ARBITRUM: 42161,
   AVALANCHE: 43114,
 };
 
@@ -20,6 +21,7 @@ const endpoints = {
   [CHAIN_ID.BSC]: "https://relay.bsc.fra.gelato.digital/relay",
   [CHAIN_ID.MATIC]: "https://relay.matic.fra.gelato.digital/relay",
   [CHAIN_ID.FANTOM]: "https://relay.fantom.fra.gelato.digital/relay",
+  [CHAIN_ID.ARBITRUM]: "https://relay.arbitrum.fra.gelato.digital/relay",
   [CHAIN_ID.AVALANCHE]: "https://relay.avalanche.fra.gelato.digital/relay",
 };
 


### PR DESCRIPTION
## The Problem

There was not support for Arbitrum using the Gelato Relayer

## The Solution

We added a Gelato relayer that supports Arbitrum

## Checklist

- [x] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
