### PR TITLE
subgraph v1 lite

### DIFF
--- a/packages/subgraph/config/v1-lite.json
+++ b/packages/subgraph/config/v1-lite.json
@@ -1,0 +1,50 @@
+[
+  {
+    "subgraphName": "connext/nxtp-mainnet-v1-lite",
+    "network": "mainnet",
+    "address": "0x31eFc4AeAA7c39e54A33FDc3C46ee2Bd70ae0A09",
+    "startBlock": 13548432
+  },
+  {
+    "subgraphName": "connext/nxtp-arbitrum-one-v1-lite",
+    "network": "arbitrum-one",
+    "address": "0xcF4d2994088a8CDE52FB584fE29608b63Ec063B2",
+    "startBlock": 1915295
+  },
+  {
+    "subgraphName": "connext/nxtp-avalanche-v1-lite",
+    "network": "avalanche",
+    "address": "0x31eFc4AeAA7c39e54A33FDc3C46ee2Bd70ae0A09",
+    "startBlock": 5285668
+  },
+  {
+    "subgraphName": "connext/nxtp-bsc-v1-lite",
+    "network": "bsc",
+    "address": "0x2A9EA5e8cDDf40730f4f4F839F673a51600C314e",
+    "startBlock": 11481191
+  },
+  {
+    "subgraphName": "connext/nxtp-fantom-v1-lite",
+    "network": "fantom",
+    "address": "0x0D29d9Fa94a23e0D2F06EfC79c25144A8F51Fc4b",
+    "startBlock": 18291901
+  },
+  {
+    "subgraphName": "connext/nxtp-matic-v1-lite",
+    "network": "matic",
+    "address": "0x6090De2EC76eb1Dc3B5d632734415c93c44Fd113",
+    "startBlock": 19835794
+  },
+  {
+    "subgraphName": "connext/nxtp-moonriver-v1-lite",
+    "network": "moonriver",
+    "address": "0x373ba9aa0f48b27A977F73423039E6dE341a0C7C",
+    "startBlock": 863864
+  },
+  {
+    "subgraphName": "connext/nxtp-xdai-v1-lite",
+    "network": "xdai",
+    "address": "0x115909BDcbaB21954bEb4ab65FC2aBEE9866fa93",
+    "startBlock": 18410655
+  }
+]

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -10,6 +10,7 @@
     "purge": "yarn clean && rimraf ./node_modules",
     "deploy": "ts-node ./src/deploy.ts",
     "deploy:v0": "yarn deploy v0 v0",
+    "deploy:v1-lite": "yarn deploy v1-lite v1-lite",
     "deploy:prod": "yarn deploy v1 prod",
     "deploy:staging": "yarn deploy v1 staging",
     "prepare:local": "yarn deploy v1 local mainnet",

--- a/packages/subgraph/src/v1-lite/abis/TransactionManager.json
+++ b/packages/subgraph/src/v1-lite/abis/TransactionManager.json
@@ -1,0 +1,1813 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "addedAssetId",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "AssetAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "renounced",
+        "type": "bool"
+      }
+    ],
+    "name": "AssetOwnershipRenounced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "AssetOwnershipRenunciationProposed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "removedAssetId",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "AssetRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "LiquidityAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "LiquidityRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proposedOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipProposed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "addedRouter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "RouterAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "renounced",
+        "type": "bool"
+      }
+    ],
+    "name": "RouterOwnershipRenounced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "RouterOwnershipRenunciationProposed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "removedRouter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "RouterRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "transactionId",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "preparedBlockNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactionManager.TransactionData",
+            "name": "txData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ITransactionManager.CancelArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "TransactionCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "transactionId",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "preparedBlockNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactionManager.TransactionData",
+            "name": "txData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "relayerFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ITransactionManager.FulfillArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isContract",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "TransactionFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "transactionId",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "receivingChainTxManagerAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingChainFallback",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "callTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "callDataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "transactionId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sendingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "receivingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preparedBlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ITransactionManager.TransactionData",
+        "name": "txData",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              }
+            ],
+            "internalType": "struct ITransactionManager.InvariantTransactionData",
+            "name": "invariantData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encryptedCallData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedBid",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "bidSignature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ITransactionManager.PrepareArgs",
+        "name": "args",
+        "type": "tuple"
+      }
+    ],
+    "name": "TransactionPrepared",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_TIMEOUT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_TIMEOUT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptProposedOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      }
+    ],
+    "name": "addAssetId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "name": "addLiquidityFor",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "name": "addRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "approvedAssets",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "approvedRouters",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "assetOwnershipTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "preparedBlockNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactionManager.TransactionData",
+            "name": "txData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ITransactionManager.CancelArgs",
+        "name": "args",
+        "type": "tuple"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "receivingChainTxManagerAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingChainFallback",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "callTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "callDataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "transactionId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sendingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "receivingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preparedBlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ITransactionManager.TransactionData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "preparedBlockNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactionManager.TransactionData",
+            "name": "txData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "relayerFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ITransactionManager.FulfillArgs",
+        "name": "args",
+        "type": "tuple"
+      }
+    ],
+    "name": "fulfill",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "receivingChainTxManagerAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingChainFallback",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "callTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "callDataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "transactionId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sendingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "receivingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preparedBlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ITransactionManager.TransactionData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStoredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interpreter",
+    "outputs": [
+      {
+        "internalType": "contract IFulfillInterpreter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAssetOwnershipRenounced",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isRouterOwnershipRenounced",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "receivingChainTxManagerAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "initiator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAssetId",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "sendingChainFallback",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "receivingAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "callTo",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "sendingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "receivingChainId",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "callDataHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "transactionId",
+                "type": "bytes32"
+              }
+            ],
+            "internalType": "struct ITransactionManager.InvariantTransactionData",
+            "name": "invariantData",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encryptedCallData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedBid",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "bidSignature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "encodedMeta",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ITransactionManager.PrepareArgs",
+        "name": "args",
+        "type": "tuple"
+      }
+    ],
+    "name": "prepare",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "receivingChainTxManagerAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAssetId",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sendingChainFallback",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receivingAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "callTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "callDataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "transactionId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sendingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "receivingChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiry",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preparedBlockNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ITransactionManager.TransactionData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposeAssetOwnershipRenunciation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newlyProposed",
+        "type": "address"
+      }
+    ],
+    "name": "proposeNewOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposeRouterOwnershipRenunciation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposed",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposedTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      }
+    ],
+    "name": "removeAssetId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "assetId",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "name": "removeRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceAssetOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceRouterOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounced",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "routerBalances",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "routerOwnershipTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "variantTransactionData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/subgraph/src/v1-lite/mapping.ts
+++ b/packages/subgraph/src/v1-lite/mapping.ts
@@ -1,0 +1,243 @@
+/* eslint-disable prefer-const */
+import { BigInt, dataSource } from "@graphprotocol/graph-ts";
+
+import {
+  TransactionManager,
+  LiquidityAdded,
+  LiquidityRemoved,
+  TransactionCancelled,
+  TransactionFulfilled,
+  TransactionPrepared,
+} from "../../generated/TransactionManager/TransactionManager";
+import { Transaction, AssetBalance, Router, User } from "../../generated/schema";
+
+/**
+ * Updates the subgraph records when LiquidityAdded events are emitted. Will create a Router record if it does not exist
+ *
+ * @param event - The contract event to update the subgraph record with
+ */
+export function handleLiquidityAdded(event: LiquidityAdded): void {
+  let router = Router.load(event.params.router.toHex());
+  if (router == null) {
+    router = new Router(event.params.router.toHex());
+    router.save();
+  }
+
+  // ID is of the format ROUTER_ADDRESS-ASSET_ID
+  let assetBalanceId = event.params.assetId.toHex() + "-" + event.params.router.toHex();
+  let assetBalance = AssetBalance.load(assetBalanceId);
+  if (assetBalance == null) {
+    assetBalance = new AssetBalance(assetBalanceId);
+    assetBalance.assetId = event.params.assetId;
+    assetBalance.router = router.id;
+    assetBalance.amount = new BigInt(0);
+  }
+  // add new amount
+  assetBalance.amount = assetBalance!.amount.plus(event.params.amount);
+  assetBalance.save();
+}
+
+/**
+ * Updates the subgraph records when LiquidityRemoved events are emitted. Will create a Router record if it does not exist
+ *
+ * @param event - The contract event to update the subgraph record with
+ */
+export function handleLiquidityRemoved(event: LiquidityRemoved): void {
+  let router = Router.load(event.params.router.toHex());
+  if (router == null) {
+    router = new Router(event.params.router.toHex());
+    router.save();
+  }
+
+  // ID is of the format ROUTER_ADDRESS-ASSET_ID
+  let assetBalanceId = event.params.assetId.toHex() + "-" + event.params.router.toHex();
+  let assetBalance = AssetBalance.load(assetBalanceId);
+  // add new amount
+  assetBalance!.amount = assetBalance!.amount.minus(event.params.amount);
+  assetBalance!.save();
+}
+
+/**
+ * Creates subgraph records when TransactionPrepared events are emitted.
+ *
+ * @param event - The contract event used to create the subgraph record
+ */
+export function handleTransactionPrepared(event: TransactionPrepared): void {
+  // load user and router
+  // router should have liquidity but it may not
+  let router = Router.load(event.params.txData.router.toHex());
+  if (router == null) {
+    router = new Router(event.params.txData.router.toHex());
+    router.save();
+  }
+
+  let user = User.load(event.params.txData.user.toHex());
+  if (user == null) {
+    user = new User(event.params.txData.user.toHex());
+    user.save();
+  }
+
+  // try to get chainId from the mapping
+  let network = dataSource.network();
+  let chainId: BigInt;
+  if (network == "mainnet") {
+    chainId = BigInt.fromI32(1);
+  } else if (network == "ropsten") {
+    chainId = BigInt.fromI32(3);
+  } else if (network == "rinkeby") {
+    chainId = BigInt.fromI32(4);
+  } else if (network == "goerli") {
+    chainId = BigInt.fromI32(5);
+  } else if (network == "kovan") {
+    chainId = BigInt.fromI32(42);
+  } else if (network == "bsc") {
+    chainId = BigInt.fromI32(56);
+  } else if (network == "chapel") {
+    chainId = BigInt.fromI32(97);
+  } else if (network == "xdai") {
+    chainId = BigInt.fromI32(100);
+  } else if (network == "matic") {
+    chainId = BigInt.fromI32(137);
+  } else if (network == "fantom") {
+    chainId = BigInt.fromI32(250);
+  } else if (network == "mbase") {
+    chainId = BigInt.fromI32(1287);
+  } else if (network == "arbitrum-one") {
+    chainId = BigInt.fromI32(42161);
+  } else if (network == "fuji") {
+    chainId = BigInt.fromI32(43113);
+  } else if (network == "avalanche") {
+    chainId = BigInt.fromI32(43114);
+  } else if (network == "mumbai") {
+    chainId = BigInt.fromI32(80001);
+  } else if (network == "arbitrum-rinkeby") {
+    chainId = BigInt.fromI32(421611);
+  } else {
+    // instantiate contract to get the chainId as a fallback
+    chainId = TransactionManager.bind(event.address).getChainId();
+  }
+
+  // cannot use only transactionId because of multipath routing, this below combo will be unique for active txs
+  let transactionId =
+    event.params.transactionId.toHex() + "-" + event.params.user.toHex() + "-" + event.params.router.toHex();
+  // contract checks ensure that this cannot exist at this point, so we can safely create new
+  // NOTE: the above case is not always true since malicious users can reuse IDs to try to break the
+  // subgraph. we can protect against this by overwriting if we are able to load a Transactioln
+  let transaction = Transaction.load(transactionId);
+  if (transaction == null) {
+    transaction = new Transaction(transactionId);
+  }
+
+  // TransactionData
+  transaction.receivingChainTxManagerAddress = event.params.txData.receivingChainTxManagerAddress;
+  transaction.user = user.id;
+  transaction.router = router.id;
+  transaction.initiator = event.params.txData.initiator;
+  transaction.sendingAssetId = event.params.txData.sendingAssetId;
+  transaction.receivingAssetId = event.params.txData.receivingAssetId;
+  transaction.sendingChainFallback = event.params.txData.sendingChainFallback;
+  transaction.callTo = event.params.txData.callTo;
+  transaction.receivingAddress = event.params.txData.receivingAddress;
+  transaction.callDataHash = event.params.txData.callDataHash;
+  transaction.transactionId = event.params.txData.transactionId;
+  transaction.sendingChainId = event.params.txData.sendingChainId;
+  transaction.receivingChainId = event.params.txData.receivingChainId;
+  transaction.amount = event.params.txData.amount;
+  transaction.expiry = event.params.txData.expiry;
+  transaction.preparedBlockNumber = event.params.txData.preparedBlockNumber;
+
+  // TransactionPrepared specific
+  transaction.prepareCaller = event.params.caller;
+  transaction.prepareTransactionHash = event.transaction.hash;
+  transaction.encryptedCallData = event.params.args.encryptedCallData.toHexString();
+  transaction.encodedBid = event.params.args.encodedBid.toHexString();
+  transaction.bidSignature = event.params.args.bidSignature;
+
+  // Meta
+  transaction.prepareMeta = event.params.args.encodedMeta;
+  transaction.status = "Prepared";
+  transaction.chainId = chainId;
+  transaction.preparedTimestamp = event.block.timestamp;
+
+  transaction.save();
+
+  // router is providing liquidity on receiver prepare
+  if (chainId == transaction.receivingChainId) {
+    let assetBalanceId = transaction.receivingAssetId.toHex() + "-" + event.params.router.toHex();
+    let assetBalance = AssetBalance.load(assetBalanceId);
+    assetBalance.amount = assetBalance.amount.minus(transaction.amount);
+    assetBalance.save();
+  }
+}
+
+/**
+ * Updates subgraph records when TransactionFulfilled events are emitted
+ *
+ * @param event - The contract event used to update the subgraph
+ */
+export function handleTransactionFulfilled(event: TransactionFulfilled): void {
+  // contract checks ensure that this cannot exist at this point, so we can safely create new
+  let transactionId =
+    event.params.transactionId.toHex() + "-" + event.params.user.toHex() + "-" + event.params.router.toHex();
+  let transaction = Transaction.load(transactionId);
+  transaction!.status = "Fulfilled";
+  transaction!.relayerFee = event.params.args.relayerFee;
+  transaction!.signature = event.params.args.signature;
+  transaction!.callData = event.params.args.callData.toHexString();
+  transaction!.externalCallSuccess = event.params.success;
+  transaction!.externalCallReturnData = event.params.returnData;
+  transaction!.externalCallIsContract = event.params.isContract;
+  transaction!.fulfillCaller = event.params.caller;
+  transaction!.fulfillTransactionHash = event.transaction.hash;
+  transaction!.fulfillMeta = event.params.args.encodedMeta;
+  transaction!.fulfillTimestamp = event.block.timestamp;
+
+  transaction!.save();
+
+  // router receives liquidity back on sender fulfill
+  if (transaction.chainId == transaction.sendingChainId) {
+    let assetBalanceId = transaction.sendingAssetId.toHex() + "-" + event.params.router.toHex();
+    let assetBalance = AssetBalance.load(assetBalanceId);
+    if (assetBalance == null) {
+      assetBalance = new AssetBalance(assetBalanceId);
+      assetBalance.assetId = transaction.sendingAssetId;
+      assetBalance.router = event.params.router.toHex();
+      assetBalance.amount = new BigInt(0);
+    }
+    assetBalance.amount = assetBalance.amount.plus(transaction.amount);
+    assetBalance.save();
+  }
+}
+
+/**
+ * Updates subgraph records when TransactionCancelled events are emitted
+ *
+ * @param event - The contract event used to update the subgraph
+ */
+export function handleTransactionCancelled(event: TransactionCancelled): void {
+  // contract checks ensure that this cannot exist at this point, so we can safely create new
+  let transactionId =
+    event.params.transactionId.toHex() + "-" + event.params.user.toHex() + "-" + event.params.router.toHex();
+  let transaction = Transaction.load(transactionId);
+  transaction!.status = "Cancelled";
+  transaction!.cancelCaller = event.params.caller;
+  transaction!.cancelTransactionHash = event.transaction.hash;
+  transaction!.cancelMeta = event.params.args.encodedMeta;
+  transaction!.cancelTimestamp = event.block.timestamp;
+
+  transaction!.save();
+
+  // router receives liquidity back on receiver cancel
+  if (transaction.chainId == transaction.receivingChainId) {
+    let assetBalanceId = transaction.receivingAssetId.toHex() + "-" + event.params.router.toHex();
+    let assetBalance = AssetBalance.load(assetBalanceId);
+    if (assetBalance == null) {
+      assetBalance = new AssetBalance(assetBalanceId);
+      assetBalance.assetId = transaction.receivingAssetId;
+      assetBalance.router = event.params.router.toHex();
+      assetBalance.amount = new BigInt(0);
+    }
+    assetBalance.amount = assetBalance.amount.plus(transaction.amount);
+    assetBalance.save();
+  }
+}

--- a/packages/subgraph/src/v1-lite/schema.graphql
+++ b/packages/subgraph/src/v1-lite/schema.graphql
@@ -1,0 +1,78 @@
+type AssetBalance @entity {
+  id: ID!
+  amount: BigInt!
+  router: Router!
+  assetId: Bytes!
+}
+
+# Router represents a router and its associated liquidity
+type Router @entity {
+  id: ID!
+  assetBalances: [AssetBalance!]! @derivedFrom(field: "router")
+  transactions: [Transaction!]! @derivedFrom(field: "router")
+}
+
+enum TransactionStatus {
+  Prepared
+  Fulfilled
+  Cancelled
+}
+
+# Transaction represents a transaction
+type Transaction @entity {
+  id: ID!
+  # Subgraph Meta
+  status: TransactionStatus!
+  chainId: BigInt!
+  preparedTimestamp: BigInt!
+
+  # TransactionData
+  receivingChainTxManagerAddress: Bytes!
+  user: User!
+  router: Router!
+  initiator: Bytes!
+  sendingAssetId: Bytes!
+  receivingAssetId: Bytes!
+  sendingChainFallback: Bytes!
+  callTo: Bytes!
+  receivingAddress: Bytes!
+  callDataHash: Bytes!
+  transactionId: Bytes!
+  sendingChainId: BigInt!
+  receivingChainId: BigInt!
+  amount: BigInt!
+  expiry: BigInt!
+  preparedBlockNumber: BigInt!
+
+  # TransactionPrepared
+  encryptedCallData: String!
+  prepareCaller: Bytes
+  bidSignature: Bytes!
+  encodedBid: String!
+  prepareTransactionHash: Bytes!
+  prepareMeta: Bytes
+
+  # TransactionFulfilled
+  relayerFee: BigInt
+  signature: Bytes
+  callData: String
+  externalCallSuccess: Boolean
+  externalCallIsContract: Boolean
+  externalCallReturnData: Bytes
+  fulfillCaller: Bytes
+  fulfillTransactionHash: Bytes
+  fulfillMeta: Bytes
+  fulfillTimestamp: BigInt
+
+  # TransactionCancelled
+  cancelCaller: Bytes
+  cancelTransactionHash: Bytes
+  cancelMeta: Bytes
+  cancelTimestamp: BigInt
+}
+
+# User entity keeps track of active user transactions
+type User @entity {
+  id: ID!
+  transactions: [Transaction!]! @derivedFrom(field: "user")
+}

--- a/packages/subgraph/src/v1-lite/subgraph.template.yaml
+++ b/packages/subgraph/src/v1-lite/subgraph.template.yaml
@@ -1,0 +1,37 @@
+specVersion: 0.0.2
+schema:
+  file: ./src/v1-lite/schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: TransactionManager
+    network: "{{network}}"
+    source:
+      address: "{{address}}"
+      abi: TransactionManager
+      # prettier-ignore
+      startBlock: {{startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - LiquidityAdded
+        - LiquidityRemoved
+        - TransactionCancelled
+        - TransactionFulfilled
+        - TransactionPrepared
+      abis:
+        - name: TransactionManager
+          file: ./src/v1-lite/abis/TransactionManager.json
+      eventHandlers:
+        - event: LiquidityAdded(indexed address,indexed address,uint256,address)
+          handler: handleLiquidityAdded
+        - event: LiquidityRemoved(indexed address,indexed address,uint256,address)
+          handler: handleLiquidityRemoved
+        - event: TransactionPrepared(indexed address,indexed address,indexed bytes32,(address,address,address,address,address,address,address,address,address,bytes32,bytes32,uint256,uint256,uint256,uint256,uint256),address,((address,address,address,address,address,address,address,address,address,uint256,uint256,bytes32,bytes32),uint256,uint256,bytes,bytes,bytes,bytes))
+          handler: handleTransactionPrepared
+        - event: TransactionFulfilled(indexed address,indexed address,indexed bytes32,((address,address,address,address,address,address,address,address,address,bytes32,bytes32,uint256,uint256,uint256,uint256,uint256),uint256,bytes,bytes,bytes),bool,bool,bytes,address)
+          handler: handleTransactionFulfilled
+        - event: TransactionCancelled(indexed address,indexed address,indexed bytes32,((address,address,address,address,address,address,address,address,address,bytes32,bytes32,uint256,uint256,uint256,uint256,uint256),bytes,bytes),address)
+          handler: handleTransactionCancelled
+      file: ./src/v1-lite/mapping.ts


### PR DESCRIPTION
closes: #519

- new: v1 lite for router and sdk
- update command
- deploy subgraphs

List of subgraphs

- https://thegraph.com/hosted-service/subgraph/connext/nxtp-mainnet-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-arbitrum-one-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-fantom-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-matic-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-moonriver-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-xdai-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-avalanche-v1-lite
- https://thegraph.com/hosted-service/subgraph/connext/nxtp-bsc-v1-lite