### PR TITLE
Optimism fee fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+- [router] Add optimism fees using mainnet pricing
+- [test-ui] Minor error fixes
+
 ## 0.0.84
 
 - [utils] Update `add-router` and `deploy-subgraph` scripts to include optimism

--- a/packages/router/src/lib/helpers/shared.ts
+++ b/packages/router/src/lib/helpers/shared.ts
@@ -4,8 +4,7 @@ import {
   GAS_ESTIMATES,
   getChainData,
 } from "@connext/nxtp-utils";
-import { getAddress } from "@ethersproject/address";
-import { BigNumber, constants } from "ethers";
+import { BigNumber, constants, utils } from "ethers";
 
 import { getOracleContractAddress, getPriceOracleInterface } from "../../adapters/contract/contract";
 import { getDeployedChainIdsForGasFee } from "../../config";
@@ -28,7 +27,7 @@ export const getMainnetEquivalent = async (
   }
   const chain = chainData.get(chainId.toString())!;
   const equiv =
-    chain.assetId[getAddress(assetId)] ??
+    chain.assetId[utils.getAddress(assetId)] ??
     chain.assetId[assetId.toLowerCase()] ??
     chain.assetId[assetId.toUpperCase()] ??
     chain.assetId[assetId];
@@ -36,7 +35,7 @@ export const getMainnetEquivalent = async (
   if (!equiv || !equiv.mainnetEquivalent || !equiv.decimals) {
     throw new Error(`No mainnet equivalent found for ${assetId} on ${chainId}`);
   }
-  return { address: getAddress(equiv.mainnetEquivalent), decimals: equiv.decimals };
+  return { address: utils.getAddress(equiv.mainnetEquivalent), decimals: equiv.decimals };
 };
 
 /**

--- a/packages/router/src/lib/helpers/shared.ts
+++ b/packages/router/src/lib/helpers/shared.ts
@@ -18,7 +18,7 @@ export const getNtpTimeSeconds = async () => {
   return await _getNtpTimeSeconds();
 };
 
-const getMainnetEquivalent = async (assetId: string, chainId: number): Promise<string> => {
+export const getMainnetEquivalent = async (assetId: string, chainId: number): Promise<string> => {
   const chainData = await getChainData();
   if (!chainData || !chainData.has(chainId.toString())) {
     throw new Error(`No chain data found for ${chainId}`);

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -47,7 +47,8 @@ describe("getChainIdsForGasFee", () => {
 describe("getMainnetEquivalent", () => {
   it("should work", async () => {
     const result = await shared.getMainnetEquivalent(constants.AddressZero, 100);
-    expect(result).to.be.eq("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+    expect(result.address).to.be.eq("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+    expect(result.decimals).to.be.eq(18);
   });
 });
 

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -97,4 +97,33 @@ describe("calculateGasFeeInReceivingToken", () => {
     );
     expect(result.toNumber()).to.be.eq((5 * parseInt(GAS_ESTIMATES.prepare) * 1) / 2);
   });
+
+  it("should work if output decimals are different than mainnet equivalent decimals", async () => {
+    const getMainnetEquivalentStub = stub(shared, "getMainnetEquivalent");
+    const getMainnetDecimalsStub = stub(shared, "getMainnetDecimals");
+    const tokenStub = stub(shared, "getTokenPrice");
+    const gasStub = stub(shared, "getGasPrice");
+
+    getMainnetEquivalentStub.resolves(mkAddress("0x0"));
+    getMainnetDecimalsStub.resolves(18);
+    tokenStub.onFirstCall().resolves(BigNumber.from(1));
+    tokenStub.onSecondCall().resolves(BigNumber.from(2));
+    gasStub.resolves(BigNumber.from(5));
+
+    const extraL1 = BigNumber.from(5).mul(GAS_ESTIMATES.prepareL1).mul(1);
+    const baseL2 = BigNumber.from(5).mul(GAS_ESTIMATES.prepare).mul(1).add(extraL1);
+    const totalGas = extraL1.add(baseL2);
+    const expectedMainnetDecimal = totalGas.div(2);
+    const expected = expectedMainnetDecimal.div(BigNumber.from(10).pow(12));
+
+    const result = await shared.calculateGasFeeInReceivingToken(
+      mkAddress("0x0"),
+      1337,
+      mkAddress("0x2"),
+      10,
+      6,
+      createRequestContext("test"),
+    );
+    expect(result.toString()).to.be.eq(expected.toString());
+  });
 });

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -47,8 +47,7 @@ describe("getChainIdsForGasFee", () => {
 describe("getMainnetEquivalent", () => {
   it("should work", async () => {
     const result = await shared.getMainnetEquivalent(constants.AddressZero, 100);
-    expect(result.address).to.be.eq("0x6B175474E89094C44Da98b954EedeAC495271d0F");
-    expect(result.decimals).to.be.eq(18);
+    expect(result).to.be.eq("0x6B175474E89094C44Da98b954EedeAC495271d0F");
   });
 });
 

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -1,8 +1,8 @@
-import { expect } from "@connext/nxtp-utils";
+import { createRequestContext, expect, mkAddress, GAS_ESTIMATES } from "@connext/nxtp-utils";
 import { BigNumber } from "@ethersproject/bignumber";
-import Sinon, { stub } from "sinon";
+import { stub } from "sinon";
 import { getNtpTimeSeconds } from "../../../src/lib/helpers";
-import { getChainIdForGasFee, getGasPrice, getTokenPrice } from "../../../src/lib/helpers/shared";
+import * as shared from "../../../src/lib/helpers/shared";
 import { txServiceMock } from "../../globalTestHook";
 
 import * as ContractHelperFns from "../../../src/adapters/contract/contract";
@@ -22,7 +22,7 @@ describe("getTokenPrice", () => {
 
   it("should work", async () => {
     txServiceMock.readTx.resolves("1");
-    const result = await getTokenPrice(4, constants.AddressZero, null);
+    const result = await shared.getTokenPrice(4, constants.AddressZero, null);
     expect(result.toString()).to.be.eq("1");
   });
 });
@@ -30,16 +30,71 @@ describe("getTokenPrice", () => {
 describe("getGasPrice", () => {
   it("should work", async () => {
     txServiceMock.getGasPrice.resolves(BigNumber.from("1"));
-    const result = await getGasPrice(4, null);
+    const result = await shared.getGasPrice(4, null);
     expect(result.toString()).to.be.eq("1");
   });
 });
 
 describe("getChainIdsForGasFee", () => {
-  it("should work", async () => {
-    const result = await getChainIdForGasFee();
+  it("should work", () => {
+    const result = shared.getChainIdForGasFee();
     expect(result).to.be.includes(4);
     expect(result).to.be.includes(56);
     expect(result).to.be.includes(42161);
+  });
+});
+
+describe("getMainnetEquivalent", () => {
+  it("should work", async () => {
+    const result = await shared.getMainnetEquivalent(constants.AddressZero, 100);
+    expect(result).to.be.eq("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+  });
+});
+
+describe("calculateGasFeeInReceivingToken", () => {
+  it("should return 0 for local chains", async () => {
+    const result = await shared.calculateGasFeeInReceivingToken(
+      mkAddress("0x1"),
+      1337,
+      mkAddress("0x2"),
+      1338,
+      18,
+      createRequestContext("test"),
+    );
+    expect(result.toNumber()).to.be.eq(0);
+  });
+
+  it("should only calculate sending chain if receiving chain is not included", async () => {
+    const tokenStub = stub(shared, "getTokenPrice");
+    const gasStub = stub(shared, "getGasPrice");
+    tokenStub.onFirstCall().resolves(BigNumber.from(1));
+    tokenStub.onSecondCall().resolves(BigNumber.from(2));
+    gasStub.onFirstCall().resolves(BigNumber.from(5));
+    const result = await shared.calculateGasFeeInReceivingToken(
+      mkAddress("0x0"),
+      1,
+      mkAddress("0x2"),
+      1338,
+      18,
+      createRequestContext("test"),
+    );
+    expect(result.toNumber()).to.be.eq((5 * parseInt(GAS_ESTIMATES.fulfill) * 1) / 2);
+  });
+
+  it("should only calculate receiving chain if sending chain is not included", async () => {
+    const tokenStub = stub(shared, "getTokenPrice");
+    const gasStub = stub(shared, "getGasPrice");
+    tokenStub.onFirstCall().resolves(BigNumber.from(1));
+    tokenStub.onSecondCall().resolves(BigNumber.from(2));
+    gasStub.onFirstCall().resolves(BigNumber.from(5));
+    const result = await shared.calculateGasFeeInReceivingToken(
+      mkAddress("0x0"),
+      1338,
+      mkAddress("0x2"),
+      1,
+      18,
+      createRequestContext("test"),
+    );
+    expect(result.toNumber()).to.be.eq((5 * parseInt(GAS_ESTIMATES.prepare) * 1) / 2);
   });
 });

--- a/packages/test-ui/.env.example
+++ b/packages/test-ui/.env.example
@@ -1,2 +1,3 @@
-REACT_APP_CHAIN_PROVIDERS='{"4":"https://rinkeby.infura.io/v3/d1caeba320f94122ba8f791f50122c4c","5":"https://goerli.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"}'
-REACT_APP_SWAP_CONFIG='[{"name":"TEST","assets":[{"4":"0x82800cFeBC6bE8D65F69deA383B227e16cf70791","5":"0xcfDAD1B98bc62DACca93A92286479C997034337E"}]]'
+# Rinkeby, Goerli, TEST
+REACT_APP_CHAIN_CONFIG='{"4":{"provider":["https://rinkeby.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]},"5":{"provider":["https://goerli.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]}}'
+REACT_APP_SWAP_CONFIG='[{"name":"TEST","assets":{"4":"0x82800cFeBC6bE8D65F69deA383B227e16cf70791","5":"0xcfDAD1B98bc62DACca93A92286479C997034337E"}}]'

--- a/packages/test-ui/src/components/Swap.tsx
+++ b/packages/test-ui/src/components/Swap.tsx
@@ -63,7 +63,10 @@ export const Swap = ({ web3Provider, signer, chainData }: SwapProps): ReactEleme
 
       const address = await signer.getAddress();
 
-      const _balance = await getUserBalance(sendingChain, signer);
+      const _balance = await getUserBalance(
+        typeof sendingChain === "number" ? sendingChain : parseInt(sendingChain),
+        signer,
+      );
       console.log("_balance: ", _balance);
       setUserBalance(_balance);
       form.setFieldsValue({ receivingAddress: address });
@@ -238,17 +241,20 @@ export const Swap = ({ web3Provider, signer, chainData }: SwapProps): ReactEleme
     init();
   }, [web3Provider, signer]);
 
-  const getUserBalance = async (chainId: number, _signer: Signer) => {
+  const getUserBalance = async (_chainId: number, _signer: Signer) => {
+    if (_chainId === 0) {
+      return BigNumber.from(0);
+    }
     const address = await _signer.getAddress();
-    const sendingAssetId = swapConfig[form.getFieldValue("asset")]?.assets[chainId];
+    const sendingAssetId = swapConfig[form.getFieldValue("asset")]?.assets[_chainId];
     console.log("sendingAssetId: ", sendingAssetId);
     if (!sendingAssetId) {
       throw new Error("Bad configuration for swap");
     }
-    if (!chainProviders || !chainProviders[chainId]) {
-      throw new Error("No config for chainId");
+    if (!chainProviders || !chainProviders[_chainId]) {
+      throw new Error(`No config for chainId: ${_chainId}. Supported: ${Object.keys(chainProviders).toString()}`);
     }
-    const _balance = await getBalance(address, sendingAssetId, chainProviders[chainId].provider);
+    const _balance = await getBalance(address, sendingAssetId, chainProviders[_chainId].provider);
     return _balance;
   };
 
@@ -601,7 +607,10 @@ export const Swap = ({ web3Provider, signer, chainData }: SwapProps): ReactEleme
                             console.error("No signer available");
                             return;
                           }
-                          const _balance = await getUserBalance(val as number, signer);
+                          const _balance = await getUserBalance(
+                            typeof val === "number" ? val : parseInt(val as string),
+                            signer,
+                          );
                           setUserBalance(_balance);
                         }}
                       >

--- a/packages/utils/src/gasEstimates.ts
+++ b/packages/utils/src/gasEstimates.ts
@@ -1,4 +1,6 @@
 export const GAS_ESTIMATES = {
   prepare: "112000", // https://etherscan.io/tx/0x4e1be107ca80265b7ae65f77e00f14dd726d08dae763955fb1cf2a754d9cc1a8 example tx, add 5% buffer
   fulfill: "126000", // https://bscscan.com/tx/0xcaba240ab17f006586086cd460fffab09a028905d7c497c31667c1d5eb58e153 example tx, add 5% buffer
+  prepareL1: "17300", // https://optimistic.etherscan.io/tx/0xd3ae8d8980aa464c4256ef6c734f7eb58211a02a6016201903e30fd35ec3bff8
+  fulfillL1: "11800", // https://optimistic.etherscan.io/tx/0x280a1e70c10095d748babb85fa56fdf8285cdcae3e3962eae3dc451045c0b220
 };


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fees not implemented for optimism because oracle setup does not work on that chain yet
- Fee calculation does not include l2 + l1 gas fees

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Use mainnet pricing for optimism fees
- Update fee calculation to work with l2 and l1 fees as [calculated on optimism](https://community.optimism.io/docs/users/fees-2.0.html#fees-in-a-nutshell)

Tested on test-ui with main nets for price verification.

## Checklist

- [x] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
