### PR TITLE
Use block number for receiver fulfilled

### DIFF
--- a/packages/router/src/bindings/contractReader/index.ts
+++ b/packages/router/src/bindings/contractReader/index.ts
@@ -43,7 +43,7 @@ export const getLoopInterval = () => LOOP_INTERVAL;
 export const handlingTracker: Map<string, Tracker> = new Map();
 
 export const bindContractReader = async () => {
-  const { contractReader, logger } = getContext();
+  const { contractReader, logger, config } = getContext();
   setInterval(async () => {
     const { requestContext, methodContext } = createLoggingContext("bindContractReader");
     let transactions: ActiveTransaction<any>[] = [];
@@ -63,6 +63,31 @@ export const bindContractReader = async () => {
       logger.error("Error getting active txs, waiting for next loop", requestContext, methodContext, jsonifyError(err));
       return;
     }
+
+    // handle the case for `ReceiverFulfilled` -- in this case, the transaction will *not*
+    // be re-processed from the loop because the next logical status is `SenderFulfilled`,
+    // which is not recognized as an "active transaction". instead, the transaction
+    // should be removed from the tracker completely to avoid a memory leak
+    Object.entries(config.chainConfig).forEach(async ([chainId]) => {
+      const records = await contractReader.getSyncRecords(Number(chainId));
+      const highestSyncedBlock = Math.max(...records.map((r) => r.syncedBlock));
+      handlingTracker.forEach((value, key) => {
+        if (
+          value.chainId === Number(chainId) &&
+          value.block > 0 &&
+          value.block <= highestSyncedBlock &&
+          value.status === "ReceiverFulfilled"
+        ) {
+          logger.debug("Deleting tracker record", requestContext, methodContext, {
+            transactionId: key,
+            chainId: chainId,
+            blockNumber: value.block,
+            syncedBlock: highestSyncedBlock,
+          });
+          handlingTracker.delete(key);
+        }
+      });
+    });
 
     await handleActiveTransactions(transactions);
   }, getLoopInterval());
@@ -106,6 +131,7 @@ export const handleActiveTransactions = async (
     handlingTracker.set(transaction.crosschainTx.invariant.transactionId, {
       status: "Processing",
       chainId,
+      block: -1,
     });
 
     handleSingle(transaction, requestContext)
@@ -116,6 +142,7 @@ export const handleActiveTransactions = async (
           handlingTracker.set(transaction.crosschainTx.invariant.transactionId, {
             status: transaction.status,
             chainId,
+            block: result.blockNumber,
           });
         } else {
           handlingTracker.delete(transaction.crosschainTx.invariant.transactionId);

--- a/packages/router/src/lib/entities/contractReader.ts
+++ b/packages/router/src/lib/entities/contractReader.ts
@@ -16,6 +16,7 @@ export type TCrosschainTransactionStatus = typeof CrosschainTransactionStatus[ke
 export type Tracker = {
   chainId: number;
   status: TCrosschainTransactionStatus | "Processing";
+  block: number;
 };
 
 export type PreparePayload = {


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- `ReceiverFulfilled` transactions are never dropped from tracker

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Remove `ReceiverFulfilled` entries by block from tracker

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
