### PR TITLE
Arbitrum cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [router] delegate fee calc to chainreader
 - [sdk] integrate chainreader
 - [txservice] introduced provider syncing
+- [router] Arbitrum `block.number` handling on cancel
 
 ## 0.0.93
 

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -13,12 +13,7 @@ import { BigNumber, constants } from "ethers/lib/ethers";
 
 import { getContext } from "../../router";
 import { ContractReaderNotAvailableForChain, NoChainConfig } from "../../lib/errors";
-import {
-  ActiveTransaction,
-  SingleChainTransaction,
-  CrosschainTransactionStatus,
-  CancelPayload,
-} from "../../lib/entities";
+import { ActiveTransaction, SingleChainTransaction, CrosschainTransactionStatus } from "../../lib/entities";
 import { handlingTracker } from "../../bindings/contractReader";
 
 import {

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -65,7 +65,7 @@ const setSyncRecord = async (chainId: number, requestContext: RequestContext): P
       latestBlock,
       records: records.map((r) => ({ synced: r.synced, lag: r.lag, syncedBlock: r.syncedBlock, uri: r.uri })),
     });
-  } catch (e) {
+  } catch (e: any) {
     logger.error(`Error getting sync records for chain ${chainId}`, requestContext, methodContext, jsonifyError(e), {
       chainId,
     });
@@ -171,7 +171,16 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
         const receiverNotConfigured = toCancel.map((senderTx) => {
           return {
             crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
-            payload: {},
+            payload: {
+              hashes: {
+                sending: {
+                  prepareHash: senderTx.prepareTransactionHash,
+                  cancelHash: senderTx.cancelTransactionHash,
+                  fulfillHash: senderTx.fulfillTransactionHash,
+                },
+                receiving: {},
+              },
+            },
             status: CrosschainTransactionStatus.ReceiverNotConfigured,
           } as ActiveTransaction<"ReceiverNotConfigured">;
         });
@@ -242,7 +251,22 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
                   sending,
                   receiving,
                 },
-                payload: {},
+                payload: {
+                  hashes: {
+                    sending: {
+                      prepareHash: senderTx.prepareTransactionHash,
+                      cancelHash: senderTx.cancelTransactionHash,
+                      fulfillHash: senderTx.fulfillTransactionHash,
+                    },
+                    receiving: correspondingReceiverTx
+                      ? {
+                          prepareHash: correspondingReceiverTx.prepareTransactionHash,
+                          cancelHash: correspondingReceiverTx.cancelTransactionHash,
+                          fulfillHash: correspondingReceiverTx.fulfillTransactionHash,
+                        }
+                      : undefined,
+                  },
+                },
                 status: CrosschainTransactionStatus.SenderExpired,
               } as ActiveTransaction<"SenderExpired">;
             }
@@ -253,7 +277,15 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
               if (!receiverSynced) {
                 return {
                   crosschainTx: sdkSenderTransactionToCrosschainTransaction(senderTx),
-                  payload: {},
+                  payload: {
+                    hashes: {
+                      sending: {
+                        prepareHash: senderTx.prepareTransactionHash,
+                        cancelHash: senderTx.cancelTransactionHash,
+                        fulfillHash: senderTx.fulfillTransactionHash,
+                      },
+                    },
+                  },
                   status: CrosschainTransactionStatus.ReceiverNotConfigured,
                 } as ActiveTransaction<"ReceiverNotConfigured">;
               }
@@ -268,6 +300,13 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
                   encodedBid: senderTx.encodedBid,
                   encryptedCallData: senderTx.encryptedCallData,
                   senderPreparedHash: senderTx.prepareTransactionHash,
+                  hashes: {
+                    sending: {
+                      prepareHash: senderTx.prepareTransactionHash,
+                      cancelHash: senderTx.cancelTransactionHash,
+                      fulfillHash: senderTx.fulfillTransactionHash,
+                    },
+                  },
                 },
                 status: CrosschainTransactionStatus.SenderPrepared,
               } as ActiveTransaction<"SenderPrepared">;
@@ -299,7 +338,20 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
                   signature: correspondingReceiverTx?.signature,
                   relayerFee: correspondingReceiverTx?.relayerFee,
                   callData: correspondingReceiverTx?.callData,
-                  receiverFulfilledHash: correspondingReceiverTx?.fulfillTransactionHash,
+                  hashes: {
+                    sending: {
+                      prepareHash: senderTx.prepareTransactionHash,
+                      cancelHash: senderTx.cancelTransactionHash,
+                      fulfillHash: senderTx.fulfillTransactionHash,
+                    },
+                    receiving: correspondingReceiverTx
+                      ? {
+                          prepareHash: correspondingReceiverTx.prepareTransactionHash,
+                          cancelHash: correspondingReceiverTx.cancelTransactionHash,
+                          fulfillHash: correspondingReceiverTx.fulfillTransactionHash,
+                        }
+                      : undefined,
+                  },
                 },
                 status: CrosschainTransactionStatus.ReceiverFulfilled,
               } as ActiveTransaction<"ReceiverFulfilled">;
@@ -312,7 +364,22 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
                   sending,
                   receiving,
                 },
-                payload: {} as CancelPayload,
+                payload: {
+                  hashes: {
+                    sending: {
+                      prepareHash: senderTx.prepareTransactionHash,
+                      cancelHash: senderTx.cancelTransactionHash,
+                      fulfillHash: senderTx.fulfillTransactionHash,
+                    },
+                    receiving: correspondingReceiverTx
+                      ? {
+                          prepareHash: correspondingReceiverTx.prepareTransactionHash,
+                          cancelHash: correspondingReceiverTx.cancelTransactionHash,
+                          fulfillHash: correspondingReceiverTx.fulfillTransactionHash,
+                        }
+                      : undefined,
+                  },
+                },
                 status: CrosschainTransactionStatus.ReceiverCancelled,
               };
             }
@@ -337,12 +404,20 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
                 invariant,
                 receiving,
               },
-              payload: {},
+              payload: {
+                hashes: {
+                  receiving: {
+                    prepareHash: expTx.prepareTransactionHash,
+                    cancelHash: expTx.cancelTransactionHash,
+                    fulfillHash: expTx.fulfillTransactionHash,
+                  },
+                },
+              },
               status: CrosschainTransactionStatus.ReceiverExpired,
             } as ActiveTransaction<"ReceiverExpired">;
           });
         return filterUndefined.concat(receiverNotConfigured).concat(remainingReceiverExpired);
-      } catch (e) {
+      } catch (e: any) {
         // Set this chain's error.
         errors.set(cId, e);
         logger.error(

--- a/packages/router/src/bindings/contractReader/index.ts
+++ b/packages/router/src/bindings/contractReader/index.ts
@@ -59,7 +59,7 @@ export const bindContractReader = async () => {
           handlingTracker: [...handlingTracker],
         });
       }
-    } catch (err) {
+    } catch (err: any) {
       logger.error("Error getting active txs, waiting for next loop", requestContext, methodContext, jsonifyError(err));
       return;
     }
@@ -179,16 +179,22 @@ export const handleSingle = async (
         requestContext,
       });
     }
+    if (!_transaction.payload.hashes.sending) {
+      logger.warn("No sending hashes with SenderPrepared status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     const senderPrepareReceipt = await txService.getTransactionReceipt(
       _transaction.crosschainTx.invariant.sendingChainId,
-      _transaction.payload.senderPreparedHash,
+      _transaction.payload.hashes.sending.prepareHash,
     );
     if ((senderPrepareReceipt?.confirmations ?? 0) < chainConfig.confirmations) {
       logger.info("Waiting for safe confirmations", requestContext, methodContext, {
         txConfirmations: senderPrepareReceipt?.confirmations ?? 0,
         configuredConfirmations: chainConfig.confirmations,
         chainId: _transaction.crosschainTx.invariant.sendingChainId,
-        txHash: _transaction.payload.senderPreparedHash,
+        txHash: _transaction.payload.hashes.sending.prepareHash,
       });
       return;
     }
@@ -222,7 +228,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.receivingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const json = jsonifyError(err);
       if (safeJsonStringify(json).includes("#P:015")) {
         logger.warn("Receiver transaction already prepared", requestContext, methodContext, { error: json });
@@ -245,6 +251,7 @@ export const handleSingle = async (
               amount: transaction.crosschainTx.sending.amount,
               expiry: transaction.crosschainTx.sending.expiry,
               preparedBlockNumber: transaction.crosschainTx.sending.preparedBlockNumber,
+              preparedTransactionHash: transaction.payload.hashes.sending.prepareHash,
               side: "sender",
             },
             requestContext,
@@ -259,7 +266,7 @@ export const handleSingle = async (
             chainId: _transaction.crosschainTx.invariant.sendingChainId,
             amount: cancelRes!.gasUsed.toString(),
           });
-        } catch (cancelErr) {
+        } catch (cancelErr: any) {
           const cancelJson = jsonifyError(cancelErr);
           if (safeJsonStringify(jsonifyError(cancelErr)).includes("#C:019")) {
             logger.warn("Already cancelled", requestContext, methodContext, {
@@ -285,14 +292,20 @@ export const handleSingle = async (
       // this should not happen, this should get checked before this point
       throw new ContractReaderNotAvailableForChain(_transaction.crosschainTx.invariant.sendingChainId, {});
     }
+    if (!_transaction.payload.hashes.receiving) {
+      logger.warn("No receiving hashes with ReceiverFulfilled status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     const receiverPrepareReceipt = await txService.getTransactionReceipt(
       _transaction.crosschainTx.invariant.receivingChainId,
-      _transaction.payload.receiverFulfilledHash,
+      _transaction.payload.hashes.receiving.prepareHash,
     );
     if ((receiverPrepareReceipt?.confirmations ?? 0) < chainConfig.confirmations) {
       logger.info("Waiting for safe confirmations", requestContext, methodContext, {
         chainId: _transaction.crosschainTx.invariant.receivingChainId,
-        txHash: _transaction.payload.receiverFulfilledHash,
+        txHash: _transaction.payload.hashes.receiving.prepareHash,
         txConfirmations: receiverPrepareReceipt?.confirmations ?? 0,
         configuredConfirmations: chainConfig.confirmations,
       });
@@ -344,7 +357,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.sendingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const jsonErr = jsonifyError(err);
       if (safeJsonStringify(jsonErr).includes("#F:019")) {
         logger.warn("Sender already fulfilled", requestContext, methodContext, { error: jsonErr });
@@ -364,6 +377,12 @@ export const handleSingle = async (
       transaction.crosschainTx.invariant.transactionId,
     );
     const _transaction = transaction as ActiveTransaction<"ReceiverExpired">;
+    if (!_transaction.payload.hashes.receiving) {
+      logger.warn("No receiving hashes with ReceiverExpired status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     try {
       logger.info("Cancelling expired receiver", requestContext, methodContext);
       receipt = await cancel(
@@ -372,6 +391,7 @@ export const handleSingle = async (
           amount: _transaction.crosschainTx.receiving!.amount,
           expiry: _transaction.crosschainTx.receiving!.expiry,
           preparedBlockNumber: _transaction.crosschainTx.receiving!.preparedBlockNumber,
+          preparedTransactionHash: _transaction.payload.hashes.receiving.prepareHash,
           side: "receiver",
         },
         requestContext,
@@ -388,7 +408,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.receivingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const errJson = jsonifyError(err);
       if (safeJsonStringify(errJson).includes("#C:019")) {
         logger.warn("Already cancelled", requestContext, methodContext, { error: errJson });
@@ -408,6 +428,12 @@ export const handleSingle = async (
       transaction.crosschainTx.invariant.transactionId,
     );
     const _transaction = transaction as ActiveTransaction<"SenderExpired">;
+    if (!_transaction.payload.hashes.sending) {
+      logger.warn("No sending hashes with SenderExpired status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     try {
       logger.info("Cancelling expired sender", requestContext, methodContext);
       receipt = await cancel(
@@ -416,6 +442,7 @@ export const handleSingle = async (
           amount: _transaction.crosschainTx.sending.amount,
           expiry: _transaction.crosschainTx.sending.expiry,
           preparedBlockNumber: _transaction.crosschainTx.sending.preparedBlockNumber,
+          preparedTransactionHash: _transaction.payload.hashes.sending.prepareHash,
           side: "sender",
         },
         requestContext,
@@ -430,7 +457,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.sendingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const errJson = jsonifyError(err);
       if (safeJsonStringify(errJson).includes("#C:019")) {
         logger.warn("Already cancelled", requestContext, methodContext, { error: errJson });
@@ -454,6 +481,12 @@ export const handleSingle = async (
       "ContractReader => ReceiverCancelled",
       transaction.crosschainTx.invariant.transactionId,
     );
+    if (!_transaction.payload.hashes.sending) {
+      logger.warn("No sending hashes with ReceiverCancelled status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     try {
       logger.info("Cancelling sender after receiver cancelled", requestContext, methodContext);
       receipt = await cancel(
@@ -462,6 +495,7 @@ export const handleSingle = async (
           amount: _transaction.crosschainTx.sending.amount,
           expiry: _transaction.crosschainTx.sending.expiry,
           preparedBlockNumber: _transaction.crosschainTx.sending.preparedBlockNumber,
+          preparedTransactionHash: _transaction.payload.hashes.sending.prepareHash,
           side: "sender",
         },
         requestContext,
@@ -476,7 +510,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.sendingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const errJson = jsonifyError(err);
       if (safeJsonStringify(errJson).includes("#C:019")) {
         logger.warn("Already cancelled", requestContext, methodContext, { error: errJson });
@@ -497,6 +531,12 @@ export const handleSingle = async (
       "ContractReader => ReceiverNotConfigured",
       transaction.crosschainTx.invariant.transactionId,
     );
+    if (!_transaction.payload.hashes.sending) {
+      logger.warn("No sending hashes with ReceiverNotConfigured status", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
     try {
       logger.info("Cancelling sender because receiver is not configured", requestContext, methodContext);
       receipt = await cancel(
@@ -505,6 +545,7 @@ export const handleSingle = async (
           amount: _transaction.crosschainTx.sending.amount,
           expiry: _transaction.crosschainTx.sending.expiry,
           preparedBlockNumber: _transaction.crosschainTx.sending.preparedBlockNumber,
+          preparedTransactionHash: _transaction.payload.hashes.sending.prepareHash,
           side: "sender",
         },
         requestContext,
@@ -519,7 +560,7 @@ export const handleSingle = async (
         chainId: _transaction.crosschainTx.invariant.sendingChainId,
         amount: receipt!.gasUsed.toString(),
       });
-    } catch (err) {
+    } catch (err: any) {
       const errJson = jsonifyError(err);
       if (safeJsonStringify(errJson).includes("#C:019")) {
         logger.warn("Already cancelled", requestContext, methodContext, { error: errJson });

--- a/packages/router/src/lib/entities/cancel.ts
+++ b/packages/router/src/lib/entities/cancel.ts
@@ -1,10 +1,11 @@
 import { Type, Static } from "@sinclair/typebox";
-import { TIntegerString } from "@connext/nxtp-utils";
+import { TBytes32, TIntegerString } from "@connext/nxtp-utils";
 
 export const CancelInputSchema = Type.Object({
   amount: TIntegerString,
   expiry: Type.Number(),
   preparedBlockNumber: Type.Number(),
+  preparedTransactionHash: TBytes32,
   side: Type.RegEx(/sender|receiver/),
 });
 

--- a/packages/router/src/lib/entities/contractReader.ts
+++ b/packages/router/src/lib/entities/contractReader.ts
@@ -33,25 +33,31 @@ export type FulfillPayload = {
   callData: string;
 };
 
+export type TransactionHashes = {
+  prepareHash: string;
+  cancelHash?: string;
+  fulfillHash?: string;
+};
+
 export type CrosschainTransactionPayload = {
-  [CrosschainTransactionStatus.SenderPrepared]: PreparePayload & {
-    senderPreparedHash: string;
-  };
+  [CrosschainTransactionStatus.SenderPrepared]: PreparePayload;
   [CrosschainTransactionStatus.SenderExpired]: Record<string, never>;
   [CrosschainTransactionStatus.ReceiverNotConfigured]: Record<string, never>;
-  [CrosschainTransactionStatus.ReceiverFulfilled]: FulfillPayload & {
-    receiverFulfilledHash: string;
-  };
-  [CrosschainTransactionStatus.ReceiverCancelled]: CancelPayload & {
-    receiverCancelledHash: string;
-  };
+  [CrosschainTransactionStatus.ReceiverFulfilled]: FulfillPayload;
+  [CrosschainTransactionStatus.ReceiverCancelled]: CancelPayload;
   [CrosschainTransactionStatus.ReceiverExpired]: Record<string, never>;
 };
 
 export type ActiveTransaction<T extends TCrosschainTransactionStatus> = {
   status: T;
   crosschainTx: CrosschainTransaction;
-  payload: CrosschainTransactionPayload[T];
+  payload: {
+    hashes: {
+      sending?: TransactionHashes;
+      // ^ optional if receiver prepared w.o sender or sender subgraph behind
+      receiving?: TransactionHashes;
+    };
+  } & CrosschainTransactionPayload[T];
 };
 
 export type SingleChainTransaction = {

--- a/packages/router/test/lib/operations/cancel.spec.ts
+++ b/packages/router/test/lib/operations/cancel.spec.ts
@@ -16,21 +16,21 @@ import { SenderTxTooNew } from "../../../src/lib/errors/cancel";
 const { requestContext } = createLoggingContext("TEST", undefined, mkBytes32("0xabc"));
 
 describe("Cancel Sender Operation", () => {
+  it("should error if invariant data validation fails", async () => {
+    const _invariantDataMock = { ...invariantDataMock, user: "abc" };
+    await expect(cancel(_invariantDataMock, cancelInputMock, requestContext)).to.eventually.be.rejectedWith(
+      "Params invalid",
+    );
+  });
+
+  it("should error if prepare input validation fails", async () => {
+    const _cancelInputMock = { ...cancelInputMock, side: "buggy" };
+    await expect(cancel(invariantDataMock, _cancelInputMock, requestContext)).to.eventually.be.rejectedWith(
+      "Params invalid",
+    );
+  });
+
   describe("#cancelSender", () => {
-    it("should error if invariant data validation fails", async () => {
-      const _invariantDataMock = { ...invariantDataMock, user: "abc" };
-      await expect(cancel(_invariantDataMock, cancelInputMock, requestContext)).to.eventually.be.rejectedWith(
-        "Params invalid",
-      );
-    });
-
-    it("should error if prepare input validation fails", async () => {
-      const _cancelInputMock = { ...cancelInputMock, side: "buggy" };
-      await expect(cancel(invariantDataMock, _cancelInputMock, requestContext)).to.eventually.be.rejectedWith(
-        "Params invalid",
-      );
-    });
-
     it("should error if sender prepare tx is too recent", async () => {
       const _cancelInputMock = { ...cancelInputMock };
       const preparedTime = Math.floor(Date.now() / 1000);
@@ -80,6 +80,33 @@ describe("Cancel Sender Operation", () => {
 
       expect(contractWriterMock.cancel).to.be.calledOnceWithExactly(
         invariantDataMock.sendingChainId,
+        {
+          txData: {
+            ...invariantDataMock,
+            amount: cancelInputMock.amount,
+            expiry: cancelInputMock.expiry,
+            preparedBlockNumber: cancelInputMock.preparedBlockNumber,
+          },
+          signature: "0x",
+        },
+        requestContext,
+      );
+    });
+  });
+
+  describe("#cancelReceiver", () => {
+    it("should work", async () => {
+      const time = Math.floor(Date.now() / 1000) - SENDER_PREPARE_BUFFER_TIME - 500;
+      (contractReaderMock.getTransactionForChain as SinonStub).resolves(undefined);
+      txServiceMock.getBlock.resolves({
+        timestamp: time,
+      } as any);
+      const receipt = await cancel(invariantDataMock, { ...cancelInputMock, side: "receiver" }, requestContext);
+
+      expect(receipt).to.deep.eq(txReceiptMock);
+
+      expect(contractWriterMock.cancel).to.be.calledOnceWithExactly(
+        invariantDataMock.receivingChainId,
         {
           txData: {
             ...invariantDataMock,

--- a/packages/router/test/utils.ts
+++ b/packages/router/test/utils.ts
@@ -86,10 +86,15 @@ export const fulfillInputMock: FulfillInput = {
   side: "receiver",
 };
 
+export const mockHashes = {
+  prepareHash: mkBytes32("0xa"),
+};
+
 export const cancelInputMock: CancelInput = {
   amount: variantDataMock.amount,
   expiry: variantDataMock.expiry,
   preparedBlockNumber: variantDataMock.preparedBlockNumber,
+  preparedTransactionHash: mockHashes.prepareHash,
   side: "sender",
 };
 
@@ -106,7 +111,7 @@ export const activeTransactionPrepareMock: ActiveTransaction<"SenderPrepared"> =
     bidSignature: "0xdbc",
     encodedBid: "0xdef",
     encryptedCallData: "0xabc",
-    senderPreparedHash: mkBytes32("0xa"),
+    hashes: { sending: mockHashes },
   },
   status: CrosschainTransactionStatus.SenderPrepared,
 };
@@ -117,7 +122,7 @@ export const activeTransactionFulfillMock: ActiveTransaction<"ReceiverFulfilled"
     callData: "0x",
     relayerFee: "100000",
     signature: "0xabc",
-    receiverFulfilledHash: mkBytes32("0xa"),
+    hashes: { sending: mockHashes, receiving: { ...mockHashes, fulfillHash: mkBytes32("0xb") } },
   },
   status: CrosschainTransactionStatus.ReceiverFulfilled,
 };


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- On Arbitrum, `block.number` means the l1 block number-ish. [Documentation here](https://developer.offchainlabs.com/docs/time_in_arbitrum#ethereum-block-numbers-within-arbitrum).
- When checking the timestamp of the sending transaction before cancelling, you must use the `receipt.blockNumber` to get the proper l2 block

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Pull expiry block number from receipt in `cancel`

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [x] Update CHANGELOG.md.
