### PR TITLE
[txservice] Expose txservice config; parse and apply defaults internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- [txservice] Update / expose config vars
+
 # 0.0.99
 
 - [txservice] Fix error parsing

--- a/packages/integration/test/load/txserviceConcurrency.ts
+++ b/packages/integration/test/load/txserviceConcurrency.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 import PriorityQueue from "p-queue";
 import { ChainConfig, NxtpTxServiceEvents, TransactionService, WriteTransaction } from "@connext/nxtp-txservice";
-import { delay, getOnchainBalance, jsonifyError, Logger, RequestContext } from "@connext/nxtp-utils";
+import { getOnchainBalance, jsonifyError, Logger, RequestContext } from "@connext/nxtp-utils";
 import { BigNumber, constants, Contract, utils, Wallet } from "ethers";
 // eslint-disable-next-line node/no-extraneous-import
 import { One } from "@ethersproject/constants";
@@ -87,13 +87,7 @@ const txserviceConcurrencyTest = async (
 
   /// MARK - SETUP TX SERVICE.
   logger.info("Creating TransactionService...");
-  const txservice = new TransactionService(
-    new Logger({ level: config.logLevel ?? "debug" }),
-    {
-      chains,
-    },
-    wallet,
-  );
+  const txservice = new TransactionService(new Logger({ level: config.logLevel ?? "debug" }), chains, wallet);
 
   /// MARK - VALIDATE FUNDS.
   // Make sure the funder has enough funding for this test.

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -103,7 +103,6 @@ export const getDeployedMulticallContract = (chainId: number): { address: string
 export const TChainConfig = Type.Object({
   providers: Type.Array(Type.String()),
   confirmations: Type.Number({ minimum: 1 }),
-  defaultInitialGasPrice: Type.Optional(TIntegerString),
   subgraph: Type.Array(Type.String()),
   transactionManagerAddress: Type.String(),
   priceOracleAddress: Type.Optional(Type.String()),

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -7,7 +7,7 @@ import {
   Logger,
   RouterNxtpNatsMessagingService,
 } from "@connext/nxtp-utils";
-import { ChainConfig, TransactionService } from "@connext/nxtp-txservice";
+import { TransactionService } from "@connext/nxtp-txservice";
 
 import { getConfig, NxtpRouterConfig } from "./config";
 import { ContractReader, subgraphContractReader } from "./adapters/subgraph";
@@ -66,21 +66,11 @@ export const makeRouter = async () => {
       logger: context.logger,
     });
     await context.messaging.connect();
-    const chains: { [chainId: string]: ChainConfig } = {};
-    Object.entries(context.config.chainConfig).forEach(([chainId, config]) => {
-      chains[chainId] = {
-        confirmations: config.confirmations,
-        providers: config.providers.map((url) => ({ url })),
-        gasStations: config.gasStations,
-        defaultInitialGasPrice: config.defaultInitialGasPrice,
-      } as ChainConfig;
-    });
+
     // TODO: txserviceconfig log level
     context.txService = new TransactionService(
       context.logger.child({ module: "TransactionService" }, context.config.logLevel),
-      {
-        chains,
-      },
+      context.config.chainConfig as any,
       context.wallet,
     );
 

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -108,23 +108,7 @@ export const createMessagingEvt = <T>() => {
 };
 
 export const setupChainReader = (logger: Logger, chainConfig: SdkBaseChainConfigParams): ChainReader => {
-  const chains: { [chainId: number]: { providers: { url: string; user?: string; password?: string }[] } } = {};
-  Object.keys(chainConfig).forEach((_chainId) => {
-    const chainId = parseInt(_chainId);
-    // Backwards compatibility with specifying only a single provider under the key "provider".
-    const _providers = chainConfig[chainId].providers ?? (chainConfig as any)[chainId].provider;
-    const providers = typeof _providers === "string" ? [_providers] : _providers;
-    chains[chainId] = {
-      providers: providers.map((provider) =>
-        typeof provider === "string"
-          ? {
-              url: provider,
-            }
-          : provider,
-      ),
-    };
-  });
-  return new ChainReader(logger, { chains });
+  return new ChainReader(logger, chainConfig);
 };
 
 /**

--- a/packages/txservice/src/config.ts
+++ b/packages/txservice/src/config.ts
@@ -140,6 +140,7 @@ export const validateTransactionServiceConfig = (_config: any): TransactionServi
     ...DEFAULT_CHAIN_CONFIG,
     ...userDefaultChainConfig,
   };
+  // For each chain, validate the config and merge it with the main config.
   const config: { [chainId: string]: ChainConfig } = {};
   Object.entries(_config).forEach(([chainId, _config]) => {
     const config = _config as any;
@@ -162,13 +163,16 @@ export const validateTransactionServiceConfig = (_config: any): TransactionServi
       config.providers ?? config.provider;
     const providers = typeof _providers === "string" ? [{ url: _providers }] : _providers;
 
-    // Remove subgraphs from the mix.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { subgraphs, ...remainingConfig } = config;
+    // Remove unused from the mix (such as subgraphs, etc).
+    // NOTE: We use CoreChainConfigSchema here because we do not want providers in the core config.
+    const sanitizedCoreConfig: any = {};
+    Object.keys(CoreChainConfigSchema.properties).forEach((property) => {
+      sanitizedCoreConfig[property] = config[property];
+    });
 
     config[chainId] = {
       ...defaultChainConfig,
-      ...remainingConfig,
+      ...sanitizedCoreConfig,
       providers: providers.map((provider) =>
         typeof provider === "string"
           ? {

--- a/packages/txservice/src/config.ts
+++ b/packages/txservice/src/config.ts
@@ -3,6 +3,8 @@ import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { parseUnits } from "ethers/lib/utils";
 
+import { ConfigurationError } from "./error";
+
 const TIntegerString = Type.RegEx(/^([0-9])*$/);
 const TUrl = Type.String({ format: "uri" });
 
@@ -60,71 +62,51 @@ export const ProviderConfigSchema = Type.Object({
 export type ProviderConfig = Static<typeof ProviderConfigSchema>;
 export const validateProviderConfig = ajv.compile(ProviderConfigSchema);
 
-// TODO: Since moving to exposing the txservice config through the "all" entry in the chainConfig
-// for router json configuration file, we should converge on a single config schema.
-// For example, imagine gasLimitInflation being able to be applied to "all" (and overriden through
-// specification per chain).
-
 /// CHAIN CONFIG
-export const ChainConfigSchema = Type.Object({
-  // List of configurations for providers for this chain.
-  providers: Type.Array(ProviderConfigSchema),
-
-  // Hardcoded initial value for gas. This shouldn't be used normally - only temporarily
-  // in the event that a gas station is malfunctioning.
-  defaultInitialGasPrice: Type.Optional(TIntegerString),
+const CoreChainConfigSchema = Type.Object({
+  /// GAS STATIONS
   // Gas station URL, if any, to retrieve current gas price from. If gas station is down or otherwise fails,
   // we'll use the RPC provider's gas as a backup.
   // Gas station should return a "rapid" gas price within the response.data.
   gasStations: Type.Optional(Type.Array(Type.String())),
-  // An integer value by which we will inflate the gas LIMIT that is returned by the provider (flat increase).
-  // Use this if your provider is returning low values and you're getting "out of gas" call exceptions.
-  gasLimitInflation: Type.Optional(Type.Integer()),
 
-  // The amount of time (ms) to wait before a confirmation polling period times out,
-  // indicating we should resubmit tx with higher gas if the tx is not confirmed.
-  confirmationTimeout: Type.Optional(Type.Integer()),
-  // Number of confirmations needed for each chain, specified by chain Id.
-  confirmations: Type.Optional(Type.Integer()),
-});
-
-export type ChainConfig = Static<typeof ChainConfigSchema>;
-export const validateChainConfig = ajv.compile(ChainConfigSchema);
-
-/// TX SERVICE CONFIG
-const TransactionServiceConfigSchema = Type.Object({
-  /// GAS
-  // % to bump gas by from gas station quote.
-  gasInitialBumpPercent: Type.Integer(),
+  /// GAS PRICE
+  // % to bump gas by from provider or gas station initial quote.
+  gasPriceInitialBoostPercent: Type.Integer(),
   // % to bump gas by when tx confirmation times out.
-  gasReplacementBumpPercent: Type.Integer(),
+  gasPriceReplacementBumpPercent: Type.Integer(),
   // Gas shouldn't ever exceed this amount.
-  gasMaximum: TIntegerString,
+  gasPriceMaximum: TIntegerString,
   // Minimum gas price.
-  gasMinimum: TIntegerString,
+  gasPriceMinimum: TIntegerString,
   // Each time we submit a tx, this is the percentage scalar we use to set the maximum for the gas price we assign it.
   // The higher this number is, the more tolerant we are of gas price increases. The lower it is, the more we curb
   // increases in gas price from tx to tx.
   // NOTE: This value should ALWAYS be greater than 100, unless you want to disable it entirely (in which case, just set it to 0).
   gasPriceMaxIncreaseScalar: Type.Integer(),
+  // Hardcoded initial value for gas. This shouldn't be used normally - only temporarily
+  // in the event that a gas station is malfunctioning.
+  hardcodedGasPrice: Type.Optional(TIntegerString),
+
+  /// GAS LIMIT
+  // An integer value by which we will inflate the gas LIMIT that is returned by the provider (flat increase).
+  // Use this if your provider is returning low values and you're getting "out of gas" call exceptions.
+  gasLimitInflation: Type.Optional(Type.Integer()),
 
   /// CONFIRMATIONS
-  // Default number of confirmations we require for a tx.
-  defaultConfirmationsRequired: Type.Integer(),
-  // Default amount of time (ms) to wait before a confirmation polling period times out.
-  defaultConfirmationTimeout: Type.Integer(),
+  // The amount of time (ms) to wait before a confirmation polling period times out,
+  // indicating we should resubmit tx with higher gas if the tx is not confirmed.
+  confirmationTimeout: Type.Integer(),
+  // Number of confirmations needed for each chain, specified by chain Id.
+  confirmations: Type.Integer(),
 
   /// RPC PROVIDERS
-  // How often (ms) we will check all RPC providers to measure how in-sync they are with the blockchain.
-  // By default, every 5 mins (5 * 60_000).
-  syncProvidersInterval: Type.Integer(),
   // Target maximum provider calls per second. Default is 4. Will NOT actually cap calls per second, but rather deprioritize
   // a provider if it reaches the maximum calls per second.
   maxProviderCPS: Type.Integer(),
-
-  /// CHAINS
-  // Configuration for each chain that this txservice will be supporting.
-  chains: Type.Record(TIntegerString, ChainConfigSchema),
+  // How often (ms) we will check all RPC providers to measure how in-sync they are with the blockchain.
+  // By default, every 5 mins (5 * 60_000).
+  syncProvidersInterval: Type.Integer(),
 
   /// DEBUGGING / DEVELOPMENT
   // WARNING: Please do not alter these configuration values; they should be used for development and/or debugging
@@ -133,27 +115,89 @@ const TransactionServiceConfigSchema = Type.Object({
   debug_logRpcCalls: Type.Boolean(),
 });
 
-export type TransactionServiceConfig = Static<typeof TransactionServiceConfigSchema>;
-export const validateTransactionServiceConfig = ajv.compile(TransactionServiceConfigSchema);
+export type CoreChainConfig = Static<typeof CoreChainConfigSchema>;
 
-// Set up the default configuration for TransactionServiceConfig.
-export const DEFAULT_CONFIG: TransactionServiceConfig = {
-  gasInitialBumpPercent: 30,
+const ChainConfigSchema = Type.Intersect([
+  Type.Object({
+    /// PROVIDERS
+    // List of configurations for providers for this chain.
+    providers: Type.Array(ProviderConfigSchema),
+  }),
+  CoreChainConfigSchema,
+]);
+
+export type ChainConfig = Static<typeof ChainConfigSchema>;
+
+/// TX SERVICE CONFIG
+// Configuration for each chain that this txservice will be supporting.
+const TransactionServiceConfigSchema = Type.Record(TIntegerString, ChainConfigSchema);
+
+export type TransactionServiceConfig = Static<typeof TransactionServiceConfigSchema>;
+export const validateTransactionServiceConfig = (_config: any): TransactionServiceConfig => {
+  // Get the default (aka "all") values to be used as defaults for all chain configs.
+  const userDefaultChainConfig = _config["all"] ?? _config["default"] ?? {};
+  const defaultChainConfig = {
+    ...DEFAULT_CHAIN_CONFIG,
+    ...userDefaultChainConfig,
+  };
+  const config: { [chainId: string]: ChainConfig } = {};
+  Object.entries(_config).forEach(([chainId, _config]) => {
+    const config = _config as any;
+    if (isNaN(parseInt(chainId))) {
+      return;
+    }
+    // Make sure gasPriceMaxIncreaseScalar > 100.
+    if (config.gasPriceMaxIncreaseScalar && config.gasPriceMaxIncreaseScalar < 100) {
+      throw new ConfigurationError([
+        {
+          parameter: "gasPriceMaxIncreaseScalar",
+          error: "gasPriceMaxIncreaseScalar must be greater than 100.",
+          value: config.gasPriceMaxIncreaseScalar,
+        },
+      ]);
+    }
+
+    // Backwards compatibility with specifying only a single provider under the key "provider".
+    const _providers: string | string[] | { url: string; user?: string; password?: string }[] =
+      config.providers ?? config.provider;
+    const providers = typeof _providers === "string" ? [{ url: _providers }] : _providers;
+
+    // Remove subgraphs from the mix.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { subgraphs, ...remainingConfig } = config;
+
+    config[chainId] = {
+      ...defaultChainConfig,
+      ...remainingConfig,
+      providers: providers.map((provider) =>
+        typeof provider === "string"
+          ? {
+              url: provider,
+            }
+          : provider,
+      ),
+    } as ChainConfig;
+  });
+  ajv.compile(TransactionServiceConfigSchema)(config);
+  return config;
+};
+
+// Set up the default configuration for CoreChainConfig.
+export const DEFAULT_CHAIN_CONFIG: CoreChainConfig = {
+  syncProvidersInterval: 5 * 60_000,
+  maxProviderCPS: 4,
+  gasPriceInitialBoostPercent: 30,
+  gasStations: [],
   // From ethers docs:
   // Generally, the new gas price should be about 50% + 1 wei more, so if a gas price
   // of 10 gwei was used, the replacement should be 15.000000001 gwei.
-  gasReplacementBumpPercent: 20,
-  gasMaximum: parseUnits("1500", "gwei").toString(),
-  gasMinimum: parseUnits("5", "gwei").toString(),
+  gasPriceReplacementBumpPercent: 20,
+  gasPriceMaximum: parseUnits("1500", "gwei").toString(),
+  gasPriceMinimum: parseUnits("5", "gwei").toString(),
   gasPriceMaxIncreaseScalar: 200,
-
+  confirmations: 10,
   // NOTE: This should be the amount of time we are willing to wait for a transaction
   // to get 1 confirmation.
-  defaultConfirmationTimeout: 90_000,
-  defaultConfirmationsRequired: 10,
-
-  syncProvidersInterval: 5 * 60_000,
-  maxProviderCPS: 4,
-
+  confirmationTimeout: 90_000,
   debug_logRpcCalls: false,
-} as TransactionServiceConfig;
+};

--- a/packages/txservice/src/dispatch.ts
+++ b/packages/txservice/src/dispatch.ts
@@ -23,7 +23,7 @@ import {
   NotEnoughConfirmations,
   TransactionAlreadyKnown,
 } from "./error";
-import { ChainConfig, TransactionServiceConfig } from "./config";
+import { ChainConfig } from "./config";
 import { ChainRpcProvider } from "./provider";
 
 export type DispatchCallbacks = {
@@ -75,13 +75,12 @@ export class TransactionDispatch extends ChainRpcProvider {
   constructor(
     logger: Logger,
     public readonly chainId: number,
-    chainConfig: ChainConfig,
-    config: TransactionServiceConfig,
+    config: ChainConfig,
     signer: string | Signer,
     private readonly callbacks: DispatchCallbacks,
     startLoops = true,
   ) {
-    super(logger, chainId, chainConfig, config, signer);
+    super(logger, chainId, config, signer);
     this.inflightBuffer = new TransactionBuffer(logger, TransactionDispatch.MAX_INFLIGHT_TRANSACTIONS, {
       name: "INFLIGHT",
       chainId: this.chainId,
@@ -372,8 +371,8 @@ export class TransactionDispatch extends ChainRpcProvider {
               nonce,
               gas,
               {
-                confirmationTimeout: this.confirmationTimeout,
-                confirmationsRequired: this.confirmationsRequired,
+                confirmationTimeout: this.config.confirmationTimeout,
+                confirmationsRequired: this.config.confirmations,
               },
               txsId,
             );
@@ -665,10 +664,10 @@ export class TransactionDispatch extends ChainRpcProvider {
 
     // Here we wait for the target confirmations.
     // TODO: Ensure we are comfortable with how this timeout period is calculated.
-    const timeout = this.confirmationTimeout * this.confirmationsRequired * 2;
+    const timeout = this.config.confirmationTimeout * this.config.confirmations * 2;
     let receipt: providers.TransactionReceipt;
     try {
-      receipt = await this.confirmTransaction(transaction, this.confirmationsRequired, timeout);
+      receipt = await this.confirmTransaction(transaction, this.config.confirmations, timeout);
     } catch (error) {
       this.logger.error(
         "Did not get enough confirmations for a *mined* transaction! Did a re-org occur?",
@@ -679,12 +678,12 @@ export class TransactionDispatch extends ChainRpcProvider {
           chainId: this.chainId,
           transaction: transaction.loggable,
           confirmations: transaction.receipt.confirmations,
-          confirmationsRequired: this.confirmationsRequired,
+          confirmationsRequired: this.config.confirmations,
         },
       );
       // No other errors should normally occur during this confirmation attempt. This could occur during a reorg.
       throw new NotEnoughConfirmations(
-        this.confirmationsRequired,
+        this.config.confirmations,
         transaction.receipt.transactionHash,
         transaction.receipt.confirmations,
         {
@@ -732,7 +731,7 @@ export class TransactionDispatch extends ChainRpcProvider {
     const { requestContext, methodContext } = createLoggingContext(this.bump.name, transaction.context);
     if (
       transaction.bumps >= transaction.hashes.length ||
-      transaction.gas.price.gte(BigNumber.from(this.config.gasMaximum))
+      transaction.gas.price.gte(BigNumber.from(this.config.gasPriceMaximum))
     ) {
       // If we've already bumped this tx but it's failed to resubmit, we should return here without bumping.
       // The number of gas bumps we've done should always be less than the number of txs we've submitted.
@@ -740,7 +739,7 @@ export class TransactionDispatch extends ChainRpcProvider {
         chainId: this.chainId,
         bumps: transaction.bumps,
         gasPrice: utils.formatUnits(transaction.gas.price, "gwei"),
-        gasMaximum: utils.formatUnits(this.config.gasMaximum, "gwei"),
+        gasMaximum: utils.formatUnits(this.config.gasPriceMaximum, "gwei"),
       });
       return;
     }
@@ -749,14 +748,14 @@ export class TransactionDispatch extends ChainRpcProvider {
     // Get the current gas baseline price, in case it's changed drastically in the last block.
     let updatedPrice: BigNumber;
     try {
-      updatedPrice = await this.getGasPrice(requestContext);
+      updatedPrice = await this.getGasPrice(requestContext, false);
     } catch {
-      updatedPrice = BigNumber.from(this.config.gasMinimum);
+      updatedPrice = BigNumber.from(this.config.gasPriceMinimum);
     }
     const determinedBaseline = updatedPrice.gt(previousPrice) ? updatedPrice : previousPrice;
     // Scale up gas by percentage as specified by config.
     transaction.gas.price = determinedBaseline
-      .add(determinedBaseline.mul(this.config.gasReplacementBumpPercent).div(100))
+      .add(determinedBaseline.mul(this.config.gasPriceReplacementBumpPercent).div(100))
       .add(1);
     this.logger.info(`Tx bumped.`, requestContext, methodContext, {
       chainId: this.chainId,

--- a/packages/txservice/src/error.ts
+++ b/packages/txservice/src/error.ts
@@ -277,8 +277,11 @@ export class ProviderNotConfigured extends NxtpError {
 export class ConfigurationError extends NxtpError {
   static readonly type = ConfigurationError.name;
 
-  constructor(public readonly invalidParamaters: any, public readonly context: any = {}) {
-    super("Configuration paramater(s) were invalid.", { ...context, invalidParamaters }, ConfigurationError.type);
+  constructor(
+    public readonly invalidParameters: { parameter: string; error: string; value: any }[],
+    public readonly context: any = {},
+  ) {
+    super("Configuration paramater(s) were invalid.", { ...context, invalidParameters }, ConfigurationError.type);
   }
 }
 

--- a/packages/txservice/src/provider.ts
+++ b/packages/txservice/src/provider.ts
@@ -10,7 +10,7 @@ import {
 import axios from "axios";
 import { BigNumber, Signer, Wallet, providers, constants, Contract, utils } from "ethers";
 
-import { TransactionServiceConfig, validateProviderConfig, ChainConfig } from "./config";
+import { validateProviderConfig, ChainConfig } from "./config";
 import {
   ConfigurationError,
   GasEstimateInvalid,
@@ -57,9 +57,6 @@ export class ChainRpcProvider {
   // Cache of transient data (i.e. data that can change per block).
   private cache: ProviderCache<ChainRpcProviderCache>;
 
-  public readonly confirmationsRequired: number;
-  public readonly confirmationTimeout: number;
-
   /**
    * A class for managing the usage of an ethers FallbackProvider, and for wrapping calls in
    * retries. Will ensure provider(s) are ready before any use case.
@@ -77,18 +74,14 @@ export class ChainRpcProvider {
   constructor(
     protected readonly logger: Logger,
     public readonly chainId: number,
-    protected readonly chainConfig: ChainConfig,
-    protected readonly config: TransactionServiceConfig,
+    protected readonly config: ChainConfig,
     signer?: string | Signer,
   ) {
     const { requestContext, methodContext } = createLoggingContext("ChainRpcProvider.constructor");
 
-    this.confirmationsRequired = chainConfig.confirmations ?? config.defaultConfirmationsRequired;
-    this.confirmationTimeout = chainConfig.confirmationTimeout ?? config.defaultConfirmationTimeout;
-
     // Register a provider for each url.
     // Make sure all providers are ready()
-    const providerConfigs = chainConfig.providers;
+    const providerConfigs = this.config.providers;
     const filteredConfigs = providerConfigs.filter((config) => {
       const valid = validateProviderConfig(config);
       if (!valid) {
@@ -120,11 +113,15 @@ export class ChainRpcProvider {
       // Not enough valid providers were found in configuration.
       // We must throw here, as the router won't be able to support this chain without valid provider configs.
       throw new ConfigurationError(
+        [
+          {
+            parameter: "providers",
+            error: "No valid providers were supplied in configuration for this chain.",
+            value: providerConfigs,
+          },
+        ],
         {
-          providers: `No valid providers were supplied in configuration for chain ${this.chainId}.`,
-        },
-        {
-          providers,
+          chainId,
         },
       );
     }
@@ -191,8 +188,8 @@ export class ChainRpcProvider {
    */
   public async confirmTransaction(
     transaction: OnchainTransaction,
-    confirmations: number = this.confirmationsRequired,
-    timeout: number = this.confirmationTimeout,
+    confirmations: number = this.config.confirmations,
+    timeout: number = this.config.confirmationTimeout,
   ): Promise<providers.TransactionReceipt> {
     const start = Date.now();
     // Using a timed out variable calculated at the end of the loop - this way we can be sure at
@@ -299,7 +296,7 @@ export class ChainRpcProvider {
    * @returns A BigNumber representing the estimated gas value.
    */
   public async estimateGas(transaction: providers.TransactionRequest): Promise<BigNumber> {
-    const { gasLimitInflation } = this.chainConfig;
+    const { gasLimitInflation } = this.config;
 
     return this.execute(false, async (provider: SyncProvider) => {
       // This call will prepare the transaction params for us (hexlify tx, etc).
@@ -317,14 +314,19 @@ export class ChainRpcProvider {
 
   /**
    * Get the current gas price for the chain for which this instance is servicing.
+   *
+   * @param context - RequestContext instance in which we are executing this method.
+   * @param useInitialBoost (default: true) - boolean indicating whether to use the configured initial boost
+   * percentage value.
+   *
    * @returns The BigNumber value for the current gas price.
    */
-  public async getGasPrice(context: RequestContext): Promise<BigNumber> {
+  public async getGasPrice(context: RequestContext, useInitialBoost = true): Promise<BigNumber> {
     const { requestContext, methodContext } = createLoggingContext(this.getGasPrice.name, context);
 
     // Check if there is a hardcoded value specified for this chain. This should usually only be set
     // for testing/overriding purposes.
-    const hardcoded = this.chainConfig.defaultInitialGasPrice;
+    const hardcoded = this.config.hardcodedGasPrice;
     if (hardcoded) {
       this.logger.info("Using hardcoded gas price for chain", requestContext, methodContext, {
         chainId: this.chainId,
@@ -338,11 +340,11 @@ export class ChainRpcProvider {
       return this.cache.data.gasPrice;
     }
 
-    const { gasInitialBumpPercent, gasMinimum, gasMaximum, gasPriceMaxIncreaseScalar } = this.config;
+    const { gasPriceInitialBoostPercent, gasPriceMinimum, gasPriceMaximum, gasPriceMaxIncreaseScalar } = this.config;
     let gasPrice: BigNumber | undefined = undefined;
 
     // Use gas station APIs, if available.
-    const gasStations = this.chainConfig.gasStations ?? [];
+    const gasStations = this.config.gasStations ?? [];
     for (let i = 0; i < gasStations.length; i++) {
       const uri = gasStations[i];
       let response: any;
@@ -373,7 +375,9 @@ export class ChainRpcProvider {
       gasPrice = await this.execute<BigNumber>(false, async (provider: SyncProvider) => {
         return await provider.getGasPrice();
       });
-      gasPrice = gasPrice.add(gasPrice.mul(gasInitialBumpPercent).div(100));
+      if (useInitialBoost) {
+        gasPrice = gasPrice.add(gasPrice.mul(gasPriceInitialBoostPercent).div(100));
+      }
     }
 
     // Apply a curbing function (if applicable) - this will curb the effect of dramatic network gas spikes.
@@ -401,8 +405,8 @@ export class ChainRpcProvider {
     // Final step to ensure we remain within reasonable, configured bounds for gas price.
     // If the gas price is less than absolute gas minimum, bump it up to minimum.
     // If it's greater than (or equal to) the absolute maximum, set it to that maximum (and log).
-    const min = BigNumber.from(gasMinimum);
-    const max = BigNumber.from(gasMaximum);
+    const min = BigNumber.from(gasPriceMinimum);
+    const max = BigNumber.from(gasPriceMaximum);
     if (gasPrice.lt(min)) {
       gasPrice = min;
     } else if (gasPrice.gte(max)) {

--- a/packages/txservice/test/chainreader.spec.ts
+++ b/packages/txservice/test/chainreader.spec.ts
@@ -448,7 +448,7 @@ describe("ChainReader", () => {
 
   describe("#setupProviders", () => {
     it("throws if not a single provider config is provided for a chainId", async () => {
-      (chainReader as any).config.chains = {
+      (chainReader as any).config = {
         [TEST_SENDER_CHAIN_ID.toString()]: {
           // Providers list here should never be empty.
           providers: [],

--- a/packages/txservice/test/chainservice.spec.ts
+++ b/packages/txservice/test/chainservice.spec.ts
@@ -8,6 +8,7 @@ import { ConfigurationError, ProviderNotConfigured, TransactionReverted } from "
 import { getRandomBytes32, RequestContext, expect, Logger, NxtpError } from "@connext/nxtp-utils";
 import { EvtError } from "evt";
 import { Gas, NxtpTxServiceEvents, OnchainTransaction } from "../src/types";
+import { ChainConfig, DEFAULT_CHAIN_CONFIG } from "../src/config";
 
 const logger = new Logger({
   level: process.env.LOG_LEVEL ?? "silent",
@@ -25,10 +26,10 @@ let dispatchCallbacks: DispatchCallbacks;
 let transaction: OnchainTransaction;
 const chains = {
   [TEST_SENDER_CHAIN_ID.toString()]: {
+    ...DEFAULT_CHAIN_CONFIG,
     providers: [{ url: "https://-------------" }],
     confirmations: 1,
-    gasStations: [],
-  },
+  } as ChainConfig,
 };
 
 /// In these tests, we are testing the outer shell of chainservice - the interface, not the core functionality.
@@ -247,12 +248,11 @@ describe("ChainService", () => {
 
   describe("#setupProviders", () => {
     it("throws if not a single provider config is provided for a chainId", async () => {
-      (chainService as any).config.chains = {
+      (chainService as any).config = {
         [TEST_SENDER_CHAIN_ID.toString()]: {
           // Providers list here should never be empty.
           providers: [],
           confirmations: 1,
-          gasStations: [],
         },
       };
       expect(() => (chainService as any).setupProviders(context, signer)).to.throw(ConfigurationError);

--- a/packages/txservice/test/chainservice.spec.ts
+++ b/packages/txservice/test/chainservice.spec.ts
@@ -49,7 +49,7 @@ describe("ChainService", () => {
     );
 
     (ChainService as any).instance = undefined;
-    chainService = new ChainService(logger, { chains }, signer);
+    chainService = new ChainService(logger, chains, signer);
 
     // NOTE: Chain service SHOULD instantiate a provider for this chain and SHOULD pass VALID callbacks
     // that link to event emitters (see: DispatchCallbacks type).

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "@connext/nxtp-utils/src/expect";
 import { BigNumber, providers, Wallet } from "ethers";
 import Sinon, { createStubInstance, reset, restore, SinonStub, SinonStubbedInstance, stub } from "sinon";
 
-import { ChainConfig, DEFAULT_CONFIG } from "../src/config";
+import { ChainConfig, DEFAULT_CHAIN_CONFIG } from "../src/config";
 import { DispatchCallbacks, TransactionDispatch } from "../src/dispatch";
 import {
   BadNonce,
@@ -98,6 +98,7 @@ describe("TransactionDispatch", () => {
     (signer as any).address = ADDRESS;
 
     const chainConfig: ChainConfig = {
+      ...DEFAULT_CHAIN_CONFIG,
       providers: [
         {
           url: "https://-------------",
@@ -105,22 +106,13 @@ describe("TransactionDispatch", () => {
       ],
       confirmations: 1,
       confirmationTimeout: 10_000,
-      gasStations: [],
     };
 
     Sinon.stub(ChainRpcProvider.prototype as any, "syncProviders").resolves();
     Sinon.stub(ChainRpcProvider.prototype as any, "setBlockPeriod").resolves();
 
     // NOTE: This will start dispatch with NO loops running. We will start the loops manually in unit tests below.
-    txDispatch = new TransactionDispatch(
-      logger,
-      TEST_SENDER_CHAIN_ID,
-      chainConfig,
-      { ...DEFAULT_CONFIG },
-      signer,
-      dispatchCallbacks,
-      false,
-    );
+    txDispatch = new TransactionDispatch(logger, TEST_SENDER_CHAIN_ID, chainConfig, signer, dispatchCallbacks, false);
 
     // This will stub all dispatch methods. Methods below should be restored manually as needed.
     stubAllDispatchMethods();

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -676,7 +676,7 @@ describe("TransactionDispatch", () => {
     });
 
     it("shouldn't bump if we've reached maximum gas price", async () => {
-      const max = (txDispatch as any).config.gasMaximum;
+      const max = (txDispatch as any).config.gasPriceMaximum;
       transaction.gas.price = BigNumber.from(max);
       // Valid state: we've sent off 2 transactions and bumped once.
       (transaction as any).responses = [TEST_TX_RESPONSE, TEST_TX_RESPONSE];

--- a/packages/txservice/test/provider.spec.ts
+++ b/packages/txservice/test/provider.spec.ts
@@ -373,7 +373,7 @@ describe("ChainRpcProvider", () => {
       const testGasPrice = utils.parseUnits("100", "gwei") as BigNumber;
       // Gas price gets bumped by X% in this method.
       const expectedGas = testGasPrice
-        .add(testGasPrice.mul((chainProvider as any).config.gasInitialBumpPercent).div(100))
+        .add(testGasPrice.mul((chainProvider as any).config.gasPriceInitialBoostPercent).div(100))
         .toString();
       coreSyncProvider.getGasPrice.resolves(testGasPrice);
 
@@ -395,7 +395,7 @@ describe("ChainRpcProvider", () => {
     it("should use cached gas price if calls < 3 seconds apart", async () => {
       const testGasPrice = utils.parseUnits("80", "gwei") as BigNumber;
       const expectedGas = testGasPrice
-        .add(testGasPrice.mul((chainProvider as any).config.gasInitialBumpPercent).div(100))
+        .add(testGasPrice.mul((chainProvider as any).config.gasPriceInitialBoostPercent).div(100))
         .toString();
       coreSyncProvider.getGasPrice.resolves(testGasPrice);
 
@@ -417,11 +417,11 @@ describe("ChainRpcProvider", () => {
 
     it("should bump gas price up to minimum if it is below that", async () => {
       // For test reliability, start from the config value and work backwards.
-      const expectedGasPrice = (chainProvider as any).config.gasMinimum;
+      const expectedGasPrice = (chainProvider as any).config.gasPriceMinimum;
       const testGasPrice = BigNumber.from(expectedGasPrice)
         .sub(
           BigNumber.from(expectedGasPrice)
-            .mul((chainProvider as any).config.gasInitialBumpPercent)
+            .mul((chainProvider as any).config.gasPriceInitialBoostPercent)
             .div(100),
         )
         .sub(utils.parseUnits("1", "gwei"));
@@ -467,7 +467,7 @@ describe("ChainRpcProvider", () => {
       coreSyncProvider.getGasPrice.resolves(testGasPrice);
       const axiosStub = Sinon.stub(axios, "get").rejects(new Error("test"));
       const expectedGas = testGasPrice
-        .add(testGasPrice.mul((chainProvider as any).config.gasInitialBumpPercent).div(100))
+        .add(testGasPrice.mul((chainProvider as any).config.gasPriceInitialBoostPercent).div(100))
         .toString();
 
       const result = await (chainProvider as any).getGasPrice();
@@ -491,7 +491,7 @@ describe("ChainRpcProvider", () => {
 
     it("should cap gas price if it hits configured absolute maximum", async () => {
       const testGasPrice = utils.parseUnits("100", "gwei") as BigNumber;
-      (chainProvider as any).config.gasMaximum = testGasPrice;
+      (chainProvider as any).config.gasPriceMaximum = testGasPrice;
       coreSyncProvider.getGasPrice.resolves(testGasPrice.add(utils.parseUnits("1", "gwei")));
 
       const result = await (chainProvider as any).getGasPrice();

--- a/packages/txservice/test/provider.spec.ts
+++ b/packages/txservice/test/provider.spec.ts
@@ -48,7 +48,7 @@ describe("ChainRpcProvider", () => {
     signer.connect.returns(signer);
 
     const chainId = TEST_SENDER_CHAIN_ID;
-    const chainConfig: ChainConfig = {
+    const config: ChainConfig = {
       ...DEFAULT_CHAIN_CONFIG,
       providers: [
         {
@@ -57,11 +57,10 @@ describe("ChainRpcProvider", () => {
       ],
       confirmations: 1,
       confirmationTimeout: 10_000,
-      gasStations: [],
     };
 
     syncProvidersStub = Sinon.stub(ChainRpcProvider.prototype as any, "syncProviders").resolves();
-    chainProvider = new ChainRpcProvider(logger, chainId, chainConfig, signer);
+    chainProvider = new ChainRpcProvider(logger, chainId, config, signer);
     // One block = 10ms for the purposes of testing.
     (chainProvider as any).blockPeriod = 10;
     Sinon.stub(chainProvider as any, "execute").callsFake(fakeExecuteMethod);
@@ -362,7 +361,7 @@ describe("ChainRpcProvider", () => {
 
     it("should inflate gas limit by configured inflation value", async () => {
       const testInflation = BigNumber.from(10_000);
-      (chainProvider as any).chainConfig.gasLimitInflation = testInflation;
+      (chainProvider as any).config.gasLimitInflation = testInflation;
       const result = await chainProvider.estimateGas(testTx);
       expect(result.eq(BigNumber.from(testGasLimit).add(testInflation))).to.be.true;
     });
@@ -385,7 +384,7 @@ describe("ChainRpcProvider", () => {
 
     it("should accept hardcoded values from config", async () => {
       const expectedGas = "197";
-      (chainProvider as any).chainConfig.defaultInitialGasPrice = expectedGas;
+      (chainProvider as any).config.hardcodedGasPrice = expectedGas;
       const result = await (chainProvider as any).getGasPrice();
       expect(coreSyncProvider.getGasPrice.callCount).to.equal(0);
       expect(result.toString()).to.be.eq(expectedGas);
@@ -451,7 +450,7 @@ describe("ChainRpcProvider", () => {
     it("should use gas station if available", async () => {
       const testGasPriceGwei = 42;
       const testGasPrice = utils.parseUnits(testGasPriceGwei.toString(), "gwei") as BigNumber;
-      (chainProvider as any).chainConfig.gasStations = ["...fakeaddy..."];
+      (chainProvider as any).config.gasStations = ["...fakeaddy..."];
       const axiosStub = Sinon.stub(axios, "get").resolves({ data: { fast: testGasPriceGwei.toString() } });
 
       const result = await (chainProvider as any).getGasPrice();
@@ -463,7 +462,7 @@ describe("ChainRpcProvider", () => {
 
     it("should resort to provider gas price if gas station fails", async () => {
       const testGasPrice = utils.parseUnits("42", "gwei") as BigNumber;
-      (chainProvider as any).chainConfig.gasStations = ["...fakeaddy..."];
+      (chainProvider as any).config.gasStations = ["...fakeaddy..."];
       coreSyncProvider.getGasPrice.resolves(testGasPrice);
       const axiosStub = Sinon.stub(axios, "get").rejects(new Error("test"));
       const expectedGas = testGasPrice
@@ -479,7 +478,7 @@ describe("ChainRpcProvider", () => {
 
     it("should handle unexpected params as a gas station failure", async () => {
       const testGasPrice = utils.parseUnits("42", "gwei") as BigNumber;
-      (chainProvider as any).chainConfig.gasStations = ["...fakeaddy..."];
+      (chainProvider as any).config.gasStations = ["...fakeaddy..."];
       coreSyncProvider.getGasPrice.resolves(testGasPrice);
       const axiosStub = Sinon.stub(axios, "get").resolves({ data: "bad data, so sad! :(" });
 

--- a/packages/txservice/test/provider.spec.ts
+++ b/packages/txservice/test/provider.spec.ts
@@ -3,7 +3,7 @@ import Sinon, { restore, reset, createStubInstance, SinonStubbedInstance, SinonS
 
 import { Gas, OnchainTransaction, SyncProvider } from "../src/types";
 import { ChainRpcProvider } from "../src/provider";
-import { ChainConfig, DEFAULT_CONFIG } from "../src/config";
+import { ChainConfig, DEFAULT_CHAIN_CONFIG } from "../src/config";
 import {
   makeChaiReadable,
   TEST_FULL_TX,
@@ -49,6 +49,7 @@ describe("ChainRpcProvider", () => {
 
     const chainId = TEST_SENDER_CHAIN_ID;
     const chainConfig: ChainConfig = {
+      ...DEFAULT_CHAIN_CONFIG,
       providers: [
         {
           url: "https://-------------",
@@ -60,17 +61,7 @@ describe("ChainRpcProvider", () => {
     };
 
     syncProvidersStub = Sinon.stub(ChainRpcProvider.prototype as any, "syncProviders").resolves();
-    chainProvider = new ChainRpcProvider(
-      logger,
-      chainId,
-      chainConfig,
-      {
-        ...DEFAULT_CONFIG,
-        gasInitialBumpPercent: 20,
-        gasPriceMaxIncreaseScalar: 200,
-      },
-      signer,
-    );
+    chainProvider = new ChainRpcProvider(logger, chainId, chainConfig, signer);
     // One block = 10ms for the purposes of testing.
     (chainProvider as any).blockPeriod = 10;
     Sinon.stub(chainProvider as any, "execute").callsFake(fakeExecuteMethod);


### PR DESCRIPTION
## The Problem

- txservice config unexposed, unable to access except by named property in router
- parsing code for passing in the chain config for txs is redundant and in many places

## The Solution

- Expose config for txservice
- Parse config internally in txservice
- Specify config vars for txservice for all chains by passing in by using "all" or "default" under "chainConfig" in the config.json
- Any config vars except for providers may be passed into "all"/"default": and they will be overwritten by config vars belonging to specific chains.
- Simplified config passed to children objects in txservice
- better naming for txservice config vars (mostly around "gasPrice", etc)

## Checklist

- [ ] Make sure backwards compat!
- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] **ACTUALLY UPDATE DOCUMENTATION TO SHOW CONFIG**
- [ ] Update CHANGELOG.md.
