### PR TITLE
[router] Hotfix: handle setting gas price vs eip-1559 gas fee based on type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - [router] Cleanup prometheus collection
+- [router/txservice] Explicitly use legacy transactions only
 
 # 0.0.99
 

--- a/packages/router/src/adapters/web3signer/index.ts
+++ b/packages/router/src/adapters/web3signer/index.ts
@@ -64,7 +64,7 @@ export class Web3Signer extends Signer {
         chainId: tx.chainId || undefined,
       },
       // If an EIP-1559 transaction, use the EIP-1559 specific fields.
-      tx.type && tx.type === 2
+      tx.type === 2
         ? {
             maxFeePerGas: tx.maxFeePerGas,
             maxPriorityFeePerGas: tx.maxPriorityFeePerGas,

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -34,6 +34,5 @@ describe("getTokenPriceFromOnChain", () => {
   });
   it("should work", async () => {
     const tokenPrice = await shared.getTokenPriceFromOnChain(1337, mkAddress("0xa"));
-    console.log("tokenPrice = ", tokenPrice.toString());
   });
 });

--- a/packages/txservice/src/types.ts
+++ b/packages/txservice/src/types.ts
@@ -16,12 +16,6 @@ export type WriteTransaction = {
   value: BigNumberish;
 } & ReadTransaction;
 
-export type FullTransaction = {
-  nonce: number;
-  gasPrice: BigNumber;
-  gasLimit: BigNumber;
-} & WriteTransaction;
-
 /// Events
 export type TxServiceSubmittedEvent = {
   responses: providers.TransactionResponse[];
@@ -195,7 +189,7 @@ export class OnchainTransaction {
   /**
    * Retrieves all params needed to format a full transaction, including current gas price set, nonce, etc.
    */
-  public get params(): FullTransaction {
+  public get params(): providers.TransactionRequest {
     return {
       ...this.minTx,
       gasPrice: this.gas.price,

--- a/packages/txservice/src/types.ts
+++ b/packages/txservice/src/types.ts
@@ -195,6 +195,8 @@ export class OnchainTransaction {
       gasPrice: this.gas.price,
       nonce: this.nonce,
       gasLimit: this.gas.limit,
+      // TODO: Support EIP-1559 transactions.
+      type: 0,
     };
   }
 

--- a/packages/txservice/test/constants.ts
+++ b/packages/txservice/test/constants.ts
@@ -2,7 +2,7 @@ import { providers, BigNumber } from "ethers";
 import { AddressZero, One, Zero } from "@ethersproject/constants";
 import { mkHash, mkAddress } from "@connext/nxtp-utils";
 
-import { FullTransaction, ReadTransaction, WriteTransaction } from "../src/types";
+import { ReadTransaction, WriteTransaction } from "../src/types";
 
 type TransactionReceipt = providers.TransactionReceipt;
 type TransactionResponse = providers.TransactionResponse;
@@ -38,7 +38,7 @@ export const TEST_TX_RESPONSE: TransactionResponse = {
   wait: () => Promise.resolve({} as TransactionReceipt),
 };
 
-export const TEST_FULL_TX: FullTransaction = {
+export const TEST_FULL_TX: providers.TransactionRequest = {
   ...TEST_TX,
   nonce: 1,
   gasPrice: TEST_TX_RESPONSE.gasPrice,


### PR DESCRIPTION
## The Problem

- web3signer was presuming we were sending a legacy transaction
- ethers was secretly converting it to a eip-1559 tx whenever possible

## The Solution

- added check for the type of tx in web3signer (0 = legacy; 2 = eip-1559)
- force all txs to be legacy for now, bc ethers conversion to eip-1559 is really gas-inefficient.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
