### PR TITLE
Active for router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - [router] Undefined handling in `bindPrices`
+- [router/sdk] Get active transactions specific to users and routers
 
 # 0.0.101
 

--- a/packages/router/src/adapters/subgraph/runtime/graphqlsdk.ts
+++ b/packages/router/src/adapters/subgraph/runtime/graphqlsdk.ts
@@ -79,6 +79,7 @@ export enum AssetBalance_OrderBy {
 export type Block_Height = {
   hash?: Maybe<Scalars['Bytes']>;
   number?: Maybe<Scalars['Int']>;
+  number_gte?: Maybe<Scalars['Int']>;
 };
 
 
@@ -105,6 +106,7 @@ export type Query = {
 export type QueryAssetBalanceArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -115,12 +117,14 @@ export type QueryAssetBalancesArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<AssetBalance_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryRouterArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -131,12 +135,14 @@ export type QueryRoutersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Router_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryTransactionArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -147,12 +153,14 @@ export type QueryTransactionsArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Transaction_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryUserArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -163,6 +171,7 @@ export type QueryUsersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<User_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -230,6 +239,7 @@ export type Subscription = {
 export type SubscriptionAssetBalanceArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -240,12 +250,14 @@ export type SubscriptionAssetBalancesArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<AssetBalance_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionRouterArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -256,12 +268,14 @@ export type SubscriptionRoutersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Router_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionTransactionArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -272,12 +286,14 @@ export type SubscriptionTransactionsArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Transaction_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionUserArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -288,6 +304,7 @@ export type SubscriptionUsersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<User_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -356,6 +373,8 @@ export type Transaction_Filter = {
   id_not_in?: Maybe<Array<Scalars['ID']>>;
   status?: Maybe<TransactionStatus>;
   status_not?: Maybe<TransactionStatus>;
+  status_in?: Maybe<Array<TransactionStatus>>;
+  status_not_in?: Maybe<Array<TransactionStatus>>;
   chainId?: Maybe<Scalars['BigInt']>;
   chainId_not?: Maybe<Scalars['BigInt']>;
   chainId_gt?: Maybe<Scalars['BigInt']>;
@@ -781,6 +800,14 @@ export type GetTransactionsQueryVariables = Exact<{
 
 export type GetTransactionsQuery = { __typename?: 'Query', transactions: Array<{ __typename?: 'Transaction', id: string, status: TransactionStatus, chainId: any, initiator: any, receivingChainTxManagerAddress: any, sendingAssetId: any, receivingAssetId: any, sendingChainFallback: any, receivingAddress: any, callTo: any, sendingChainId: any, receivingChainId: any, callDataHash: any, transactionId: any, amount: any, expiry: any, preparedBlockNumber: any, relayerFee?: Maybe<any>, signature?: Maybe<any>, callData?: Maybe<string>, prepareCaller?: Maybe<any>, fulfillCaller?: Maybe<any>, cancelCaller?: Maybe<any>, prepareTransactionHash: any, fulfillTransactionHash?: Maybe<any>, cancelTransactionHash?: Maybe<any>, user: { __typename?: 'User', id: string }, router: { __typename?: 'Router', id: string } }> };
 
+export type GetTransactionsWithRouterQueryVariables = Exact<{
+  transactionIds?: Maybe<Array<Scalars['Bytes']> | Scalars['Bytes']>;
+  routerId: Scalars['String'];
+}>;
+
+
+export type GetTransactionsWithRouterQuery = { __typename?: 'Query', transactions: Array<{ __typename?: 'Transaction', id: string, status: TransactionStatus, chainId: any, initiator: any, receivingChainTxManagerAddress: any, sendingAssetId: any, receivingAssetId: any, sendingChainFallback: any, receivingAddress: any, callTo: any, sendingChainId: any, receivingChainId: any, callDataHash: any, transactionId: any, amount: any, expiry: any, preparedBlockNumber: any, relayerFee?: Maybe<any>, signature?: Maybe<any>, callData?: Maybe<string>, prepareCaller?: Maybe<any>, fulfillCaller?: Maybe<any>, cancelCaller?: Maybe<any>, prepareTransactionHash: any, fulfillTransactionHash?: Maybe<any>, cancelTransactionHash?: Maybe<any>, user: { __typename?: 'User', id: string }, router: { __typename?: 'Router', id: string } }> };
+
 export type GetAssetBalanceQueryVariables = Exact<{
   assetBalanceId: Scalars['ID'];
 }>;
@@ -967,6 +994,44 @@ export const GetTransactionsDocument = gql`
   }
 }
     `;
+export const GetTransactionsWithRouterDocument = gql`
+    query GetTransactionsWithRouter($transactionIds: [Bytes!], $routerId: String!) {
+  transactions(where: {transactionId_in: $transactionIds, router: $routerId}) {
+    id
+    status
+    chainId
+    user {
+      id
+    }
+    router {
+      id
+    }
+    initiator
+    receivingChainTxManagerAddress
+    sendingAssetId
+    receivingAssetId
+    sendingChainFallback
+    receivingAddress
+    callTo
+    sendingChainId
+    receivingChainId
+    callDataHash
+    transactionId
+    amount
+    expiry
+    preparedBlockNumber
+    relayerFee
+    signature
+    callData
+    prepareCaller
+    fulfillCaller
+    cancelCaller
+    prepareTransactionHash
+    fulfillTransactionHash
+    cancelTransactionHash
+  }
+}
+    `;
 export const GetAssetBalanceDocument = gql`
     query GetAssetBalance($assetBalanceId: ID!) {
   assetBalance(id: $assetBalanceId) {
@@ -1010,6 +1075,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetTransactions(variables?: GetTransactionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetTransactionsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetTransactionsQuery>(GetTransactionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTransactions');
+    },
+    GetTransactionsWithRouter(variables: GetTransactionsWithRouterQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetTransactionsWithRouterQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTransactionsWithRouterQuery>(GetTransactionsWithRouterDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTransactionsWithRouter');
     },
     GetAssetBalance(variables: GetAssetBalanceQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetAssetBalanceQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetAssetBalanceQuery>(GetAssetBalanceDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetAssetBalance');

--- a/packages/router/src/adapters/subgraph/runtime/queries.ts
+++ b/packages/router/src/adapters/subgraph/runtime/queries.ts
@@ -178,6 +178,45 @@ export const getTransactionsByIdsQuery = gql`
   }
 `;
 
+export const getTransactionsByIdsWithRouterQuery = gql`
+  query GetTransactionsWithRouter($transactionIds: [Bytes!], $routerId: String!) {
+    transactions(where: { transactionId_in: $transactionIds, router: $routerId }) {
+      id
+      status
+      chainId
+      user {
+        id
+      }
+      router {
+        id
+      }
+      initiator
+      receivingChainTxManagerAddress
+      sendingAssetId
+      receivingAssetId
+      sendingChainFallback
+      receivingAddress
+      callTo
+      sendingChainId
+      receivingChainId
+      callDataHash
+      transactionId
+      amount
+      expiry
+      preparedBlockNumber
+      relayerFee
+      signature
+      callData
+      prepareCaller
+      fulfillCaller
+      cancelCaller
+      prepareTransactionHash
+      fulfillTransactionHash
+      cancelTransactionHash
+    }
+  }
+`;
+
 export const getAssetBalanceById = gql`
   query GetAssetBalance($assetBalanceId: ID!) {
     assetBalance(id: $assetBalanceId) {

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -210,7 +210,10 @@ export const getActiveTransactions = async (_requestContext?: RequestContext): P
               return [];
             }
             const query = await _sdk.request<GetTransactionsQuery>((client) =>
-              client.GetTransactions({ transactionIds: txIds.map((t) => t.toLowerCase()) }),
+              client.GetTransactionsWithRouter({
+                transactionIds: txIds.map((t) => t.toLowerCase()),
+                routerId: routerAddress.toLowerCase(),
+              }),
             );
             return query.transactions;
           }),

--- a/packages/router/test/adapters/subgraph/subgraph.spec.ts
+++ b/packages/router/test/adapters/subgraph/subgraph.spec.ts
@@ -31,6 +31,7 @@ type SdkMock = {
   GetTransaction: SinonStub;
   GetAssetBalance: SinonStub;
   GetBlockNumber: SinonStub;
+  GetTransactionsWithRouter: SinonStub;
 };
 
 let sdks: Record<number, SinonStubbedInstance<FallbackSubgraph<SdkMock>>>;
@@ -62,6 +63,7 @@ describe("Subgraph Adapter", () => {
       GetTransaction: stub().resolves(undefined),
       GetAssetBalance: stub().resolves(constants.Zero),
       GetBlockNumber: stub().resolves({ _meta: { block: { number: 10000 } } }),
+      GetTransactionsWithRouter: stub().resolves({ transactions: [] }),
     };
 
     txServiceMock.getBlockNumber.resolves(10000);
@@ -188,7 +190,7 @@ describe("Subgraph Adapter", () => {
         },
       });
       const testError = new Error("fail");
-      sdk.GetTransactions.rejects(testError);
+      sdk.GetTransactionsWithRouter.rejects(testError);
 
       try {
         await getActiveTransactions(requestContextMock);
@@ -249,7 +251,7 @@ describe("Subgraph Adapter", () => {
           },
         };
       });
-      sdk.GetTransactions.onCall(0).callsFake(async ({ transactionIds }) => {
+      sdk.GetTransactionsWithRouter.onCall(0).callsFake(async ({ transactionIds }) => {
         const expectedId = transactionSubgraphMock.transactionId.toLowerCase();
         expect(transactionIds).to.deep.eq([expectedId]);
         return {
@@ -280,7 +282,7 @@ describe("Subgraph Adapter", () => {
           },
         };
       });
-      sdk.GetTransactions.onCall(0).callsFake(async ({ transactionIds }) => {
+      sdk.GetTransactionsWithRouter.onCall(0).callsFake(async ({ transactionIds }) => {
         const expectedId = transactionSubgraphMock.transactionId.toLowerCase();
         expect(transactionIds).to.deep.eq([expectedId]);
         return {
@@ -310,7 +312,7 @@ describe("Subgraph Adapter", () => {
           },
         };
       });
-      sdk.GetTransactions.onCall(0).callsFake(async ({ transactionIds }) => {
+      sdk.GetTransactionsWithRouter.onCall(0).callsFake(async ({ transactionIds }) => {
         const expectedId = transactionSubgraphMock.transactionId.toLowerCase();
         expect(transactionIds).to.deep.eq([expectedId]);
         return {

--- a/packages/router/test/bindings/contractReader/index.spec.ts
+++ b/packages/router/test/bindings/contractReader/index.spec.ts
@@ -6,10 +6,9 @@ import {
   delay,
   getRandomBytes32,
   RequestContextWithTransactionId,
-  VariantTransactionData,
 } from "@connext/nxtp-utils";
 import { reset, restore, SinonStub, stub } from "sinon";
-import { providers } from "ethers/lib/ethers";
+import { providers } from "ethers";
 
 import {
   ActiveTransaction,

--- a/packages/sdk/src/subgraph/graphqlsdk.ts
+++ b/packages/sdk/src/subgraph/graphqlsdk.ts
@@ -79,6 +79,7 @@ export enum AssetBalance_OrderBy {
 export type Block_Height = {
   hash?: Maybe<Scalars['Bytes']>;
   number?: Maybe<Scalars['Int']>;
+  number_gte?: Maybe<Scalars['Int']>;
 };
 
 
@@ -105,6 +106,7 @@ export type Query = {
 export type QueryAssetBalanceArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -115,12 +117,14 @@ export type QueryAssetBalancesArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<AssetBalance_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryRouterArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -131,12 +135,14 @@ export type QueryRoutersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Router_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryTransactionArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -147,12 +153,14 @@ export type QueryTransactionsArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Transaction_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryUserArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -163,6 +171,7 @@ export type QueryUsersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<User_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -230,6 +239,7 @@ export type Subscription = {
 export type SubscriptionAssetBalanceArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -240,12 +250,14 @@ export type SubscriptionAssetBalancesArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<AssetBalance_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionRouterArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -256,12 +268,14 @@ export type SubscriptionRoutersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Router_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionTransactionArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -272,12 +286,14 @@ export type SubscriptionTransactionsArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<Transaction_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionUserArgs = {
   id: Scalars['ID'];
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -288,6 +304,7 @@ export type SubscriptionUsersArgs = {
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<User_Filter>;
   block?: Maybe<Block_Height>;
+  subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
@@ -356,6 +373,8 @@ export type Transaction_Filter = {
   id_not_in?: Maybe<Array<Scalars['ID']>>;
   status?: Maybe<TransactionStatus>;
   status_not?: Maybe<TransactionStatus>;
+  status_in?: Maybe<Array<TransactionStatus>>;
+  status_not_in?: Maybe<Array<TransactionStatus>>;
   chainId?: Maybe<Scalars['BigInt']>;
   chainId_not?: Maybe<Scalars['BigInt']>;
   chainId_gt?: Maybe<Scalars['BigInt']>;
@@ -780,6 +799,14 @@ export type GetTransactionsQueryVariables = Exact<{
 
 export type GetTransactionsQuery = { __typename?: 'Query', transactions: Array<{ __typename?: 'Transaction', id: string, status: TransactionStatus, chainId: any, preparedTimestamp: any, initiator: any, receivingChainTxManagerAddress: any, sendingAssetId: any, receivingAssetId: any, sendingChainFallback: any, receivingAddress: any, callTo: any, sendingChainId: any, receivingChainId: any, callDataHash: any, transactionId: any, amount: any, expiry: any, preparedBlockNumber: any, encryptedCallData: string, encodedBid: string, bidSignature: any, relayerFee?: Maybe<any>, signature?: Maybe<any>, callData?: Maybe<string>, prepareCaller?: Maybe<any>, fulfillCaller?: Maybe<any>, cancelCaller?: Maybe<any>, prepareTransactionHash: any, fulfillTransactionHash?: Maybe<any>, cancelTransactionHash?: Maybe<any>, user: { __typename?: 'User', id: string }, router: { __typename?: 'Router', id: string } }> };
 
+export type GetTransactionsWithUserQueryVariables = Exact<{
+  transactionIds?: Maybe<Array<Scalars['Bytes']> | Scalars['Bytes']>;
+  userId: Scalars['String'];
+}>;
+
+
+export type GetTransactionsWithUserQuery = { __typename?: 'Query', transactions: Array<{ __typename?: 'Transaction', id: string, status: TransactionStatus, chainId: any, preparedTimestamp: any, initiator: any, receivingChainTxManagerAddress: any, sendingAssetId: any, receivingAssetId: any, sendingChainFallback: any, receivingAddress: any, callTo: any, sendingChainId: any, receivingChainId: any, callDataHash: any, transactionId: any, amount: any, expiry: any, preparedBlockNumber: any, encryptedCallData: string, encodedBid: string, bidSignature: any, relayerFee?: Maybe<any>, signature?: Maybe<any>, callData?: Maybe<string>, prepareCaller?: Maybe<any>, fulfillCaller?: Maybe<any>, cancelCaller?: Maybe<any>, prepareTransactionHash: any, fulfillTransactionHash?: Maybe<any>, cancelTransactionHash?: Maybe<any>, user: { __typename?: 'User', id: string }, router: { __typename?: 'Router', id: string } }> };
+
 export type GetBlockNumberQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -955,6 +982,48 @@ export const GetTransactionsDocument = gql`
   }
 }
     `;
+export const GetTransactionsWithUserDocument = gql`
+    query GetTransactionsWithUser($transactionIds: [Bytes!], $userId: String!) {
+  transactions(where: {transactionId_in: $transactionIds, user: $userId}) {
+    id
+    status
+    chainId
+    preparedTimestamp
+    user {
+      id
+    }
+    router {
+      id
+    }
+    initiator
+    receivingChainTxManagerAddress
+    sendingAssetId
+    receivingAssetId
+    sendingChainFallback
+    receivingAddress
+    callTo
+    sendingChainId
+    receivingChainId
+    callDataHash
+    transactionId
+    amount
+    expiry
+    preparedBlockNumber
+    encryptedCallData
+    encodedBid
+    bidSignature
+    relayerFee
+    signature
+    callData
+    prepareCaller
+    fulfillCaller
+    cancelCaller
+    prepareTransactionHash
+    fulfillTransactionHash
+    cancelTransactionHash
+  }
+}
+    `;
 export const GetBlockNumberDocument = gql`
     query GetBlockNumber {
   _meta {
@@ -983,6 +1052,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetTransactions(variables?: GetTransactionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetTransactionsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetTransactionsQuery>(GetTransactionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTransactions');
+    },
+    GetTransactionsWithUser(variables: GetTransactionsWithUserQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetTransactionsWithUserQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTransactionsWithUserQuery>(GetTransactionsWithUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTransactionsWithUser');
     },
     GetBlockNumber(variables?: GetBlockNumberQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetBlockNumberQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetBlockNumberQuery>(GetBlockNumberDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetBlockNumber');

--- a/packages/sdk/src/subgraph/queries.ts
+++ b/packages/sdk/src/subgraph/queries.ts
@@ -174,6 +174,49 @@ export const getTransactionsByIdsQuery = gql`
   }
 `;
 
+export const getTransactionsByIdsWithUserQuery = gql`
+  query GetTransactionsWithUser($transactionIds: [Bytes!], $userId: String!) {
+    transactions(where: { transactionId_in: $transactionIds, user: $userId }) {
+      id
+      status
+      chainId
+      preparedTimestamp
+      user {
+        id
+      }
+      router {
+        id
+      }
+      initiator
+      receivingChainTxManagerAddress
+      sendingAssetId
+      receivingAssetId
+      sendingChainFallback
+      receivingAddress
+      callTo
+      sendingChainId
+      receivingChainId
+      callDataHash
+      transactionId
+      amount
+      expiry
+      preparedBlockNumber
+      encryptedCallData
+      encodedBid
+      bidSignature
+      relayerFee
+      signature
+      callData
+      prepareCaller
+      fulfillCaller
+      cancelCaller
+      prepareTransactionHash
+      fulfillTransactionHash
+      cancelTransactionHash
+    }
+  }
+`;
+
 export const getBlockNumber = gql`
   query GetBlockNumber {
     _meta {

--- a/packages/sdk/src/subgraph/subgraph.ts
+++ b/packages/sdk/src/subgraph/subgraph.ts
@@ -217,6 +217,7 @@ export class Subgraph {
     // Gather matching sending-chain records from the subgraph that will *not*
     // be handled by step 2 (i.e. statuses are *not* prepared)
     const nonPreparedSendingTxs: any[] = [];
+    const user = await this.userAddress;
     const correspondingReceiverTxIdsByChain: Record<string, string[]> = {};
     await Promise.all(
       Object.keys(idsBySendingChains).map(async (sendingChainId) => {
@@ -231,7 +232,7 @@ export class Subgraph {
         }
 
         const { transactions } = await subgraph.request<GetTransactionsQuery>((client) =>
-          client.GetTransactions({ transactionIds: ids }),
+          client.GetTransactionsWithUser({ transactionIds: ids, userId: user.toLowerCase() }),
         );
         if (transactions.length === 0) {
           return;
@@ -269,7 +270,7 @@ export class Subgraph {
           return;
         }
         const { transactions } = await subgraph.request<GetTransactionsQuery>((client) =>
-          client.GetTransactions({ transactionIds: ids }),
+          client.GetTransactionsWithUser({ transactionIds: ids, userId: user.toLowerCase() }),
         );
         if (transactions.length === 0) {
           return;
@@ -371,8 +372,9 @@ export class Subgraph {
                 return undefined;
               }
               const { transactions: correspondingReceiverTxs } = await _sdk.request<GetTransactionsQuery>((client) =>
-                client.GetTransactions({
+                client.GetTransactionsWithUser({
                   transactionIds: senderTxs.map((tx) => tx.transactionId),
+                  userId: user.toLowerCase(),
                 }),
               );
 
@@ -579,8 +581,9 @@ export class Subgraph {
             }
 
             const { transactions: correspondingSenderTxs } = await _sdk.request<GetTransactionsQuery>((client) =>
-              client.GetTransactions({
+              client.GetTransactionsWithUser({
                 transactionIds: receiverTxs.map((tx) => tx.transactionId),
+                userId: user.toLowerCase(),
               }),
             );
 

--- a/packages/sdk/test/unit/subgraphsdk.spec.ts
+++ b/packages/sdk/test/unit/subgraphsdk.spec.ts
@@ -28,7 +28,7 @@ describe("graphqlsdk", () => {
     const c = sdk.GetTransaction({} as any);
     expect(c).to.be.undefined;
 
-    const d = sdk.GetTransactions({} as any);
+    const d = sdk.GetTransactionsWithUser({} as any);
     expect(d).to.be.undefined;
   });
 });


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- When `getActiveTransactions` is called, it is not looking for transactions matching the router/user. this means transactions could be mis-assigned if there is reuse of txids
- See [here](https://www.notion.so/connext/Duplicate-Transaction-Ids-815d14d795bf4a23b72b860f0dadc68a)

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Always use `userId` or `routerId` when querying for active transactions

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
