### PR TITLE
[txservice] Better RPC stall timeout handling; emphasize reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- [txservice] Fixed issue with RPC stall timeout handling
 - [router] Undefined handling in `bindPrices`
 
 # 0.0.101

--- a/packages/txservice/src/shared/errors.ts
+++ b/packages/txservice/src/shared/errors.ts
@@ -25,7 +25,7 @@ export class RpcError extends NxtpError {
     FailedToSend: "Failed to send RPC transaction.",
     NetworkError: "An RPC network error occurred.",
     ConnectionReset: "Connection was reset by peer.",
-    Timeout: "Request timed out",
+    StallTimeout: "Request stalled and timed out",
   };
 
   constructor(public readonly reason: Values<typeof RpcError.reasons>, public readonly context: any = {}) {

--- a/packages/txservice/src/shared/transactionBuffer.ts
+++ b/packages/txservice/src/shared/transactionBuffer.ts
@@ -92,9 +92,11 @@ export class TransactionBuffer extends Array<OnchainTransaction> {
             break;
           }
         }
-        // This splice operation will replace that transaction in the buffer.
+        // This splice operation will insert the new transaction into the correct position in the buffer,
+        // and possibly replace an existing transaction with the same nonce.
         replacedTx = super.splice(index, shouldReplace ? 1 : 0, tx)[0];
       }
+      // This error setting will cause any processes currently using this transaction to error out.
       replacedTx.error = new TransactionBackfilled({
         replacement: tx.loggable,
       });

--- a/packages/txservice/src/shared/transactionBuffer.ts
+++ b/packages/txservice/src/shared/transactionBuffer.ts
@@ -116,7 +116,7 @@ export class TransactionBuffer extends Array<OnchainTransaction> {
   }
 
   public getTxByNonce(nonce: number): OnchainTransaction | undefined {
-    return this.find((tx) => tx.nonce === nonce) ?? this.lastShiftedTx;
+    return this.lastShiftedTx?.nonce === nonce ? this.lastShiftedTx : this.find((tx) => tx.nonce === nonce);
   }
 
   private log(message?: string, context: any = {}, error = false) {

--- a/packages/txservice/test/provider.spec.ts
+++ b/packages/txservice/test/provider.spec.ts
@@ -727,7 +727,7 @@ describe("ChainRpcProvider", () => {
         provider.lag = 0;
         provider.reliability = 0.5;
         Sinon.stub(provider, "cps").get(() => 1);
-        Sinon.stub(provider, "avgExecTime").get(() => 0.5);
+        Sinon.stub(provider, "latency").get(() => 0.5);
       }
 
       syncProvidersStub.restore();
@@ -766,7 +766,7 @@ describe("ChainRpcProvider", () => {
         // in order to isolate the logic for prioritizing based on lag.
         provider.reliability = 0.5;
         Sinon.stub(provider, "cps").get(() => 1);
-        Sinon.stub(provider, "avgExecTime").get(() => 0.5);
+        Sinon.stub(provider, "latency").get(() => 0.5);
         testProviders.push(provider);
       }
       const leadProviderUrl = "mr. lead provider";
@@ -778,10 +778,9 @@ describe("ChainRpcProvider", () => {
 
       expect(shuffledProviders).to.be.an("array");
 
-      // All providers should be in sync.
-      expect(shuffledProviders.length).to.be.eq(inSyncProvidersCount);
-      expect(shuffledProviders.every((p: SyncProvider) => p.synced)).to.be.true;
-      expect(shuffledProviders).to.not.deep.equal(testProviders);
+      // Should return list in order: first <inSyncProvidersCount> are in-sync, remaining are out-of-sync.
+      expect(shuffledProviders.slice(0, inSyncProvidersCount).every((p: SyncProvider) => p.synced)).to.be.true;
+      expect(shuffledProviders.slice(inSyncProvidersCount).every((p: SyncProvider) => p.synced)).to.be.false;
 
       // First provider should be the lead provider.
       expect(shuffledProviders[0].url).to.be.eq(leadProviderUrl);

--- a/packages/txservice/test/shared/contracts.spec.ts
+++ b/packages/txservice/test/shared/contracts.spec.ts
@@ -1,0 +1,1 @@
+describe("contracts", () => {});

--- a/packages/txservice/test/shared/syncProvider.spec.ts
+++ b/packages/txservice/test/shared/syncProvider.spec.ts
@@ -27,7 +27,7 @@ describe("SyncProvider", () => {
     expect(provider.lag).to.be.eq(0);
     expect(provider.priority).to.be.eq(0);
     expect(provider.cps).to.be.eq(0);
-    expect(provider.avgExecTime).to.be.eq(0);
+    expect(provider.latency).to.be.eq(0);
     expect(provider.reliability).to.be.eq(0);
   });
 
@@ -104,8 +104,8 @@ describe("SyncProvider", () => {
     it("success: should update its internal metrics correctly", async () => {
       (provider as any).updateMetrics(true, Date.now() - 1000, 12, "testMethodName", ["testParam1", "testParam2"]);
       expect(provider.reliability).to.be.gt(startingReliability);
-      expect(provider.avgExecTime).to.be.gt(0);
-      expect((provider as any).execTimes.length).to.be.eq(1);
+      expect(provider.latency).to.be.gt(0);
+      expect((provider as any).latencies.length).to.be.eq(1);
     });
 
     it("failure: should update its internal metrics correctly", async () => {
@@ -114,8 +114,8 @@ describe("SyncProvider", () => {
         context: {},
       });
       expect(provider.reliability).to.be.lt(startingReliability);
-      expect(provider.avgExecTime).to.be.gt(0);
-      expect((provider as any).execTimes.length).to.be.eq(1);
+      expect(provider.latency).to.be.gt(0);
+      expect((provider as any).latencies.length).to.be.eq(1);
     });
   });
 });

--- a/packages/txservice/test/shared/transactionBuffer.spec.ts
+++ b/packages/txservice/test/shared/transactionBuffer.spec.ts
@@ -15,6 +15,15 @@ describe("TransactionBuffer", () => {
   const MAX_LENGTH = 64;
   let buffer: TransactionBuffer;
 
+  const addMockTxsToBuffer = (count: number): number => {
+    let i: number;
+    for (i = 0; i < count; i++) {
+      const { transaction } = getMockOnchainTransaction(i);
+      buffer.push(transaction);
+    }
+    return i;
+  };
+
   beforeEach(() => {
     buffer = new TransactionBuffer(logger, MAX_LENGTH, {
       name: "testBuffer",
@@ -31,17 +40,40 @@ describe("TransactionBuffer", () => {
     });
 
     it("throws MaxBufferLengthError if at max length", () => {
-      let i: number;
-      for (i = 0; i < buffer.maxLength; i++) {
-        const { transaction } = getMockOnchainTransaction(i);
-        buffer.push(transaction);
-      }
+      const i = addMockTxsToBuffer(buffer.maxLength);
       const { transaction } = getMockOnchainTransaction(i + 1);
       expect(() => buffer.push(transaction)).to.throw(MaxBufferLengthError);
     });
   });
 
-  describe("#shift", () => {});
+  describe("#shift", () => {
+    it("should set lastShiftedTx", () => {
+      expect((buffer as any).lastShiftedTx).to.be.undefined;
+      const { transaction } = getMockOnchainTransaction();
+      buffer.push(transaction);
+      expect((buffer as any).lastShiftedTx).to.be.undefined;
+      buffer.shift();
+      expect((buffer as any).lastShiftedTx).to.deep.eq(transaction);
+    });
+  });
 
-  describe("#getTxByNonce", () => {});
+  describe("#getTxByNonce", () => {
+    it("should return tx with specified nonce", () => {
+      // Will be ordered by nonce, so the first tx nonce = 0, last tx nonce = 11 in this case:
+      const txCount = 12;
+      addMockTxsToBuffer(txCount);
+      expect(buffer.getTxByNonce(4)).to.deep.eq(buffer[4]);
+    });
+
+    it("should return last shifted if nonce belongs to the last shifted tx", () => {
+      addMockTxsToBuffer(3);
+      const tx = buffer.shift();
+      const nonce = tx.nonce;
+      expect(buffer.getTxByNonce(nonce)).to.deep.eq(tx);
+    });
+
+    it("should return undefined if it doesn't exist", () => {
+      expect(buffer.getTxByNonce(123)).to.be.undefined;
+    });
+  });
 });

--- a/packages/utils/src/fallbackSubgraph.ts
+++ b/packages/utils/src/fallbackSubgraph.ts
@@ -135,9 +135,7 @@ export class FallbackSubgraph<T extends SdkLike> {
               });
             }
           }),
-          new Promise<Q>((_, reject) =>
-            setTimeout(() => reject(new NxtpError("Timeout")), this.stallTimeout),
-          ),
+          new Promise<Q>((_, reject) => setTimeout(() => reject(new NxtpError("Timeout")), this.stallTimeout)),
         ]);
       } catch (e) {
         errors.push(e);
@@ -228,7 +226,6 @@ export class FallbackSubgraph<T extends SdkLike> {
     return this.sdks
       .filter((sdk) => sdk.record.synced)
       .sort((sdkA, sdkB) => sdkA.priority - sdkB.priority)
-      .concat(this.sdks.filter((sdk) => !sdk.record.synced))
-      .sort((sdkA, sdkB) => sdkA.priority - sdkB.priority);
+      .concat(this.sdks.filter((sdk) => !sdk.record.synced).sort((sdkA, sdkB) => sdkA.priority - sdkB.priority));
   }
 }


### PR DESCRIPTION
Fixes #624 

- Increased weight for reliability metric significantly in the sort order of providers.
- Renamed 'Timeout' to 'StallTimeout'
- StallTimeout errors now bring reliability of a provider instantly to 0 (bc, by default, means provider didn't respond after 10s!)
- Fixed bug in handling StallTimeout error in the `execute` method
- No longer excluding "out-of-sync" providers (i.e. providers that are behind in X # of blocks from others), but concatenating them to be chosen as a fallback.
    - The above fix ^ made me realize that the 'concat' operation I was doing in `FallbackSubgraph` had a misplaced parenthesis lol, so I also fixed that!

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
