### PR TITLE
[txservice] Hotfix: fallback if server errors occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release -
 
+- [txservice] Fix handling of RPC provider server errors
+
 # 0.0.102
 
 - [txservice] Fixed issue with RPC stall timeout handling

--- a/packages/test-ui/.env.example
+++ b/packages/test-ui/.env.example
@@ -1,3 +1,3 @@
 # Rinkeby, Goerli, TEST
-REACT_APP_CHAIN_CONFIG='{"4":{"provider":["https://rinkeby.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]},"5":{"provider":["https://goerli.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]}}'
+REACT_APP_CHAIN_CONFIG='{"1":{"providers":["https://cloudflare-eth.com"]},"4":{"providers":["https://rinkeby.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]},"5":{"providers":["https://goerli.infura.io/v3/d1caeba320f94122ba8f791f50122c4c"]}}'
 REACT_APP_SWAP_CONFIG='[{"name":"TEST","assets":{"4":"0x82800cFeBC6bE8D65F69deA383B227e16cf70791","5":"0xcfDAD1B98bc62DACca93A92286479C997034337E"}}]'

--- a/packages/txservice/src/dispatch.ts
+++ b/packages/txservice/src/dispatch.ts
@@ -15,7 +15,7 @@ import {
   BadNonce,
   TransactionReplaced,
   TransactionReverted,
-  TimeoutError,
+  OperationTimeout,
   TransactionBackfilled,
   InitialSubmitFailure,
   TransactionProcessingError,
@@ -146,7 +146,7 @@ export class TransactionDispatch extends ChainRpcProvider {
               txsId: transaction.uuid,
               error,
             });
-            if (error.type === TimeoutError.type && !receivedBadNonce) {
+            if (error.type === OperationTimeout.type && !receivedBadNonce) {
               // Check to see if this nonce has already been mined; this would imply this transaction got replaced, or
               // failed to reach chain.
               const transactionCount = await this.getTransactionCount("latest");

--- a/packages/txservice/src/shared/errors.ts
+++ b/packages/txservice/src/shared/errors.ts
@@ -13,6 +13,14 @@ export class MaxBufferLengthError extends NxtpError {
   }
 }
 
+export class StallTimeout extends NxtpError {
+  static readonly type = StallTimeout.name;
+
+  constructor(public readonly context: any = {}) {
+    super("Request stalled and timed out.", context, StallTimeout.type);
+  }
+}
+
 export class RpcError extends NxtpError {
   static readonly type = RpcError.name;
 
@@ -25,7 +33,6 @@ export class RpcError extends NxtpError {
     FailedToSend: "Failed to send RPC transaction.",
     NetworkError: "An RPC network error occurred.",
     ConnectionReset: "Connection was reset by peer.",
-    StallTimeout: "Request stalled and timed out",
   };
 
   constructor(public readonly reason: Values<typeof RpcError.reasons>, public readonly context: any = {}) {
@@ -112,14 +119,14 @@ export class TransactionReplaced extends NxtpError {
 
 // TODO: #144 Some of these error classes are a bit of an antipattern with the whole "reason" argument structure
 // being missing. They won't function as proper NxtpErrors, essentially.
-export class TimeoutError extends NxtpError {
+export class OperationTimeout extends NxtpError {
   /**
    * An error indicating that an operation (typically confirmation) timed out.
    */
-  static readonly type = TimeoutError.name;
+  static readonly type = OperationTimeout.name;
 
   constructor(public readonly context: any = {}) {
-    super("Operation timed out.", context, TimeoutError.type);
+    super("Operation timed out.", context, OperationTimeout.type);
   }
 }
 
@@ -403,7 +410,7 @@ export const parseError = (error: any): NxtpError => {
     case Logger.errors.UNPREDICTABLE_GAS_LIMIT:
       return new UnpredictableGasLimit(context);
     case Logger.errors.TIMEOUT:
-      return new TimeoutError(context);
+      return new OperationTimeout(context);
     case Logger.errors.NETWORK_ERROR:
       return new RpcError(RpcError.reasons.NetworkError, context);
     case Logger.errors.SERVER_ERROR:

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -12,7 +12,7 @@ import {
   MaxBufferLengthError,
   NotEnoughConfirmations,
   RpcError,
-  TimeoutError,
+  OperationTimeout,
   TransactionProcessingError,
   TransactionReplaced,
   TransactionReverted,
@@ -147,7 +147,7 @@ describe("TransactionDispatch", () => {
     });
 
     it("should bump if times out during confirming", async () => {
-      mineStub.onCall(0).rejects(new TimeoutError());
+      mineStub.onCall(0).rejects(new OperationTimeout());
       mineStub.onCall(1).resolves();
       await (txDispatch as any).mineLoop();
       expect(mineStub.callCount).to.eq(2);
@@ -163,11 +163,11 @@ describe("TransactionDispatch", () => {
       const stubTx2 = { ...stubTx, data: "0xb" };
       const stubTx3 = { ...stubTx, data: "0xc" };
       (txDispatch as any).inflightBuffer = [stubTx1, stubTx2, stubTx3];
-      mineStub.onCall(0).rejects(new TimeoutError());
+      mineStub.onCall(0).rejects(new OperationTimeout());
       mineStub.onCall(1).resolves();
-      mineStub.onCall(2).rejects(new TimeoutError());
+      mineStub.onCall(2).rejects(new OperationTimeout());
       mineStub.onCall(3).resolves();
-      mineStub.onCall(4).rejects(new TimeoutError());
+      mineStub.onCall(4).rejects(new OperationTimeout());
       mineStub.onCall(5).resolves();
       await (txDispatch as any).mineLoop();
 
@@ -193,7 +193,7 @@ describe("TransactionDispatch", () => {
     it("should assign errors on tx resubmit", async () => {
       const stubTx1 = { ...stubTx, data: "0xa" };
       (txDispatch as any).inflightBuffer = [stubTx1];
-      mineStub.rejects(new TimeoutError());
+      mineStub.rejects(new OperationTimeout());
       const error = new Error("test");
       submitStub.rejects(error);
       await (txDispatch as any).mineLoop();
@@ -637,7 +637,7 @@ describe("TransactionDispatch", () => {
     });
 
     it("escalates error as a TransactionServiceFailure if timeout occurs", async () => {
-      const timeoutError = new TimeoutError("test");
+      const timeoutError = new OperationTimeout("test");
       confirmTransactionStub.rejects(timeoutError);
       await expect((txDispatch as any).confirm(transaction)).to.be.rejectedWith(NotEnoughConfirmations);
     });

--- a/packages/txservice/test/shared/contracts.spec.ts
+++ b/packages/txservice/test/shared/contracts.spec.ts
@@ -1,1 +1,0 @@
-describe("contracts", () => {});

--- a/packages/txservice/test/shared/syncProvider.spec.ts
+++ b/packages/txservice/test/shared/syncProvider.spec.ts
@@ -2,7 +2,7 @@ import { randomInt } from "crypto";
 import { SinonStub, stub } from "sinon";
 import { expect } from "@connext/nxtp-utils";
 
-import { RpcError, SyncProvider } from "../../src/shared";
+import { RpcError, SyncProvider, TransactionReverted } from "../../src/shared";
 import { TEST_ERROR, TEST_SENDER_CHAIN_ID } from "../utils";
 
 describe("SyncProvider", () => {
@@ -28,7 +28,7 @@ describe("SyncProvider", () => {
     expect(provider.priority).to.be.eq(0);
     expect(provider.cps).to.be.eq(0);
     expect(provider.latency).to.be.eq(0);
-    expect(provider.reliability).to.be.eq(0);
+    expect(provider.reliability).to.be.eq(1);
   });
 
   describe("#sync", () => {
@@ -108,12 +108,23 @@ describe("SyncProvider", () => {
       expect((provider as any).latencies.length).to.be.eq(1);
     });
 
-    it("failure: should update its internal metrics correctly", async () => {
+    it("RPC failure: should update its internal metrics correctly", async () => {
       (provider as any).updateMetrics(false, Date.now() - 1000, 12, "testMethodName", ["testParam1", "testParam2"], {
-        type: "testError",
+        type: RpcError.type,
         context: {},
       });
       expect(provider.reliability).to.be.lt(startingReliability);
+      expect(provider.latency).to.be.gt(0);
+      expect((provider as any).latencies.length).to.be.eq(1);
+    });
+
+    it("non-RPC failure: should update its internal metrics correctly", async () => {
+      (provider as any).updateMetrics(false, Date.now() - 1000, 12, "testMethodName", ["testParam1", "testParam2"], {
+        type: TransactionReverted.type,
+        context: {},
+      });
+      // Reliability should be unchanged.
+      expect(provider.reliability).to.be.eq(startingReliability);
       expect(provider.latency).to.be.gt(0);
       expect((provider as any).latencies.length).to.be.eq(1);
     });


### PR DESCRIPTION
(Hopefully) fixes #627 

## The Problem

It seems we were treating `ServerError`s as an indication that an RPC call failed, when in reality they are an indication that only 1 provider failed. This would cause us to fail to fallback to the next provider.

## The Solution

- `ServerError`s are now treated correctly in `execute` wrapper method in `ChainRpcProvider`
- Changed `RpcError.reasons.StallTimeout` -> `StallTimeout`, it's own error type now
(- Also renamed `TimeoutError` to `OperationTimeout` so as to avoid confusion)
- Fixed a bug in `syncProviders()` where we did not catch (and ignore) errors in our `getBlock` calls. This was actually a pretty bad issue, as it prevented us from scoring priority of different providers correctly.
- `ServerError`s also now trigger the same severe penalty on provider's `reliability` score as `StallTimeout` errors do (reset to 0).
- `reliability` score now starts at 1 (providers are all "innocent until proven guilty" lol)

## Checklist

- [x] Test manually on `test-ui` using remote chains.
    - See stress test here: https://discord.com/channels/454734546869551114/920991835558658068/921193942580609115
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
