### PR TITLE
[sdk] Throw valid auction errors as-is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release -
 
+- [sdk] Throw valid auction errors correctly
 - [txservice] Fix handling of RPC provider server errors
 
 # 0.0.102

--- a/packages/sdk/src/error.ts
+++ b/packages/sdk/src/error.ts
@@ -27,6 +27,7 @@ export abstract class ParamsError extends NxtpError {
  * @classdesc Represents errors having to do with an auction
  */
 export abstract class AuctionError extends NxtpError {
+  readonly isAuctionError = true;
   static readonly type = AuctionError.name;
 }
 


### PR DESCRIPTION
## The Problem

We were snuffing out `NoBids` errors with `UnknownAuctionError`

## The Solution

- Added property to `AuctionError` "isAuctionError" (equal to true)
- Wrapped the whole segment of the `getTransferQuote` method in a try/catch, instead of multiple try/catches
- When we catch an error, we check `error.isAuctionError` to see if we should throw the error as-is.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
