### PR TITLE
[sdk] fees breakdown at transferQuote

### DIFF
--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,7 +1,6 @@
 import {
   TChainId,
   TAddress,
-  TIntegerString,
   TransactionDataSchema,
   PrepareParams,
   Logger,
@@ -12,6 +11,7 @@ import {
   UserNxtpNatsMessagingService,
   AuctionResponseSchema,
   ChainData,
+  TIntegerString,
 } from "@connext/nxtp-utils";
 import { Type, Static } from "@sinclair/typebox";
 import { providers, Signer } from "ethers";
@@ -106,7 +106,7 @@ export type CrossChainParams = Static<typeof CrossChainParamsSchema>;
 
 export const GetTransferQuoteSchema = Type.Intersect([
   AuctionResponseSchema,
-  Type.Object({ metaTxRelayerFee: TIntegerString }),
+  Type.Object({ totalFee: TIntegerString, routerFee: TIntegerString, metaTxRelayerFee: TIntegerString }),
 ]);
 export type GetTransferQuote = Static<typeof GetTransferQuoteSchema>;
 


### PR DESCRIPTION
closes: #604 
- add: fees break down on transferQuote response
- update: receiverAmount calc on estimateFee at sdk

## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
