### PR TITLE
fix: lower log level to debug for method start

### DIFF
--- a/packages/router/src/adapters/contract/contract.ts
+++ b/packages/router/src/adapters/contract/contract.ts
@@ -161,7 +161,7 @@ export const prepareTransactionManager = async (
   const { methodContext } = createLoggingContext(prepareTransactionManager.name);
 
   const { logger, txService, wallet } = getContext();
-  logger.info("Method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     prepareParams,
   });
 
@@ -207,7 +207,7 @@ export const prepareRouterContract = async (
   const { methodContext } = createLoggingContext(prepareRouterContract.name);
 
   const { logger, txService, wallet, messaging } = getContext();
-  logger.info("Method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     prepareParams,
     routerRelayerFeeAsset,
     routerRelayerFee,
@@ -303,7 +303,7 @@ export const fulfillTransactionManager = async (
   const { methodContext } = createLoggingContext(fulfillTransactionManager.name);
 
   const { logger, txService, wallet } = getContext();
-  logger.info("Method start", requestContext, methodContext);
+  logger.debug("Method start", requestContext, methodContext);
 
   const { txData, relayerFee, signature: fulfillSignature, callData } = fulfillParams;
 
@@ -340,7 +340,7 @@ export const fulfillRouterContract = async (
   const { methodContext } = createLoggingContext(fulfillRouterContract.name);
 
   const { logger, txService, wallet, messaging } = getContext();
-  logger.info("Method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     fulfillParams,
     routerRelayerFeeAsset,
     routerRelayerFee,
@@ -430,7 +430,7 @@ export const cancelTransactionManager = async (
   const { methodContext } = createLoggingContext(cancelTransactionManager.name);
 
   const { logger, txService, wallet } = getContext();
-  logger.info("Method start", requestContext, methodContext, { cancelParams });
+  logger.debug("Method start", requestContext, methodContext, { cancelParams });
 
   const { txData, signature: cancelSignature } = cancelParams;
   await sanitationCheck(chainId, txData, "cancel");
@@ -466,7 +466,7 @@ export const cancelRouterContract = async (
   const { methodContext } = createLoggingContext(cancelRouterContract.name);
 
   const { logger, txService, wallet, messaging } = getContext();
-  logger.info("Method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     cancelParams,
     routerRelayerFeeAsset,
     routerRelayerFee,
@@ -571,7 +571,7 @@ export const removeLiquidityTransactionManager = async (
 
   const { logger, txService, wallet, signerAddress } = getContext();
 
-  logger.info("Method start", requestContext, methodContext, { amount, assetId, recipientAddress });
+  logger.debug("Method start", requestContext, methodContext, { amount, assetId, recipientAddress });
 
   if (!recipientAddress) {
     recipientAddress = signerAddress;
@@ -608,7 +608,7 @@ export const addLiquidityForTransactionManager = async (
 
   const { logger, txService, wallet, signerAddress } = getContext();
 
-  logger.info("Method start", requestContext, methodContext, { amount, assetId, routerAddress });
+  logger.debug("Method start", requestContext, methodContext, { amount, assetId, routerAddress });
 
   if (!routerAddress) {
     routerAddress = signerAddress;
@@ -689,7 +689,7 @@ export const migrateLiquidity = async (
     return;
   }
 
-  logger.info("Method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     chainId,
     amount,
     assetId,

--- a/packages/router/src/adapters/subgraph/subgraph.ts
+++ b/packages/router/src/adapters/subgraph/subgraph.ts
@@ -595,7 +595,7 @@ export const getCancelledFulfilledTransactions = async (routerAddress: string, c
   const { logger } = getContext();
   const { requestContext, methodContext } = createLoggingContext(getCancelledFulfilledTransactions.name);
 
-  logger.info("method start", requestContext, methodContext, {
+  logger.debug("Method start", requestContext, methodContext, {
     chainId,
     routerAddress,
   });

--- a/packages/router/src/lib/operations/cancel.ts
+++ b/packages/router/src/lib/operations/cancel.ts
@@ -28,7 +28,7 @@ export const cancel = async (
 
   const { logger, contractWriter, contractReader, txService, isRouterContract, config, wallet, routerAddress } =
     getContext();
-  logger.info("Method start", requestContext, methodContext, { invariantData, input });
+  logger.debug("Method start", requestContext, methodContext, { invariantData, input });
 
   // Validate InvariantData schema
   const validateInvariantData = ajv.compile(InvariantTransactionDataSchema);

--- a/packages/router/src/lib/operations/prepare.ts
+++ b/packages/router/src/lib/operations/prepare.ts
@@ -50,7 +50,7 @@ export const prepare = async (
     routerAddress,
     signerAddress,
   } = getContext();
-  logger.info("Method start", requestContext, methodContext, { invariantData, input, requestContext });
+  logger.debug("Method start", requestContext, methodContext, { invariantData, input, requestContext });
 
   // HOTFIX: add sanitation check before cancellable validation
   await sanitationCheck(

--- a/packages/sdk/src/transactionManager/transactionManager.ts
+++ b/packages/sdk/src/transactionManager/transactionManager.ts
@@ -134,7 +134,7 @@ export class TransactionManager {
       prepareParams.txData.transactionId,
     );
 
-    this.logger.info("Method start", requestContext, methodContext, { chainId, prepareParams });
+    this.logger.debug("Method start", requestContext, methodContext, { chainId, prepareParams });
 
     this.assertChainIsConfigured(chainId);
     const { transactionManagerAddress } = this.chainConfig[chainId];
@@ -204,7 +204,7 @@ export class TransactionManager {
       cancelParams.txData.transactionId,
     );
 
-    this.logger.info("Method start", requestContext, methodContext, { cancelParams });
+    this.logger.debug("Method start", requestContext, methodContext, { cancelParams });
 
     this.assertChainIsConfigured(chainId);
     const { transactionManagerAddress } = this.chainConfig[chainId];
@@ -257,7 +257,7 @@ export class TransactionManager {
       fulfillParams.txData.transactionId,
     );
 
-    this.logger.info("Method start", requestContext, methodContext, { fulfillParams });
+    this.logger.debug("Method start", requestContext, methodContext, { fulfillParams });
 
     this.assertChainIsConfigured(chainId);
     const { transactionManagerAddress } = this.chainConfig[chainId];
@@ -306,7 +306,7 @@ export class TransactionManager {
       _requestContext,
     );
 
-    this.logger.info("Method start", requestContext, methodContext, { chainId, assetId, amount });
+    this.logger.debug("Method start", requestContext, methodContext, { chainId, assetId, amount });
 
     this.assertChainIsConfigured(chainId);
     const { transactionManagerAddress } = this.chainConfig[chainId];

--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -251,7 +251,7 @@ export class ChainReader {
       this.calculateGasFeeInReceivingToken.name,
       _requestContext,
     );
-    this.logger.info("Method start", requestContext, methodContext, {
+    this.logger.debug("Method start", requestContext, methodContext, {
       sendingChainId,
       sendingAssetId,
       sendingChainIdForGasPrice,
@@ -323,7 +323,7 @@ export class ChainReader {
       this.calculateGasFeeInReceivingTokenForFulfill.name,
       _requestContext,
     );
-    this.logger.info("Method start", requestContext, methodContext, {
+    this.logger.debug("Method start", requestContext, methodContext, {
       receivingChainId,
       receivingAssetId,
       receivingChainIdForGasPrice,


### PR DESCRIPTION
## The Problem

`Method start` logs currently add lots of noise to log output without much value

## The Solution

Changed the log level for these messages from `info` to `debug`.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
