### PR TITLE
[txservice] Check that transaction exists when mine timeout occurs.

### DIFF
--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -66,7 +66,7 @@ export class ChainReader {
    * @returns Encoded hexdata representing result of the read from the chain.
    */
   public async readTx(tx: ReadTransaction): Promise<string> {
-    return await this.getProvider(tx.chainId).readTransaction(tx);
+    return await this.getProvider(tx.chainId).readContract(tx);
   }
 
   /**

--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -18,7 +18,7 @@ import {
   getDeployedPriceOracleContract,
   getPriceOracleInterface,
 } from "./shared";
-import { ChainRpcProvider } from "./provider";
+import { RpcProviderAggregator } from "./rpcProviderAggregator";
 
 // TODO: Rename to BlockchainService
 // TODO: I do not like that this is generally a passthrough class now - all it handles is the mapping. We should
@@ -31,7 +31,7 @@ export const cachedPriceMap: Map<string, { timestamp: number; price: BigNumber }
  * @classdesc Performs onchain reads with embedded retries.
  */
 export class ChainReader {
-  protected providers: Map<number, ChainRpcProvider> = new Map();
+  protected providers: Map<number, RpcProviderAggregator> = new Map();
   protected readonly config: TransactionServiceConfig;
 
   /**
@@ -443,7 +443,7 @@ export class ChainReader {
    * @throws TransactionError.reasons.ProviderNotFound if provider is not configured for
    * that ID.
    */
-  protected getProvider(chainId: number): ChainRpcProvider {
+  protected getProvider(chainId: number): RpcProviderAggregator {
     // Ensure that a signer, provider, etc are present to execute on this chainId.
     if (!this.providers.has(chainId)) {
       throw new ProviderNotConfigured(chainId.toString());
@@ -483,7 +483,7 @@ export class ChainReader {
         throw error;
       }
       const chainIdNumber = parseInt(chainId);
-      const provider = new ChainRpcProvider(this.logger, chainIdNumber, chain, signer);
+      const provider = new RpcProviderAggregator(this.logger, chainIdNumber, chain, signer);
       this.providers.set(chainIdNumber, provider);
     });
   }

--- a/packages/txservice/src/shared/errors.ts
+++ b/packages/txservice/src/shared/errors.ts
@@ -312,7 +312,6 @@ export class TransactionProcessingError extends NxtpError {
     SubmitOutOfOrder: "Submit was called but transaction is already completed.",
     MineOutOfOrder: "Transaction mine or confirm was called, but no transaction has been sent.",
     ConfirmOutOfOrder: "Tried to confirm but tansaction did not complete 'mine' step; no receipt was found.",
-    DidNotBump: "Gas price was not incremented from last transaction.",
     DuplicateHash: "Received a transaction response with a duplicate hash!",
     NoReceipt: "No receipt was returned from the transaction.",
     NullReceipt: "Unable to obtain receipt: ethers responded with null.",

--- a/packages/txservice/test/chainreader.spec.ts
+++ b/packages/txservice/test/chainreader.spec.ts
@@ -71,17 +71,17 @@ describe("ChainReader", () => {
   describe("#readTx", () => {
     it("happy: returns exactly what it reads", async () => {
       const fakeData = getRandomBytes32();
-      provider.readTransaction.resolves(fakeData);
+      provider.readContract.resolves(fakeData);
 
       const data = await chainReader.readTx(TEST_READ_TX);
 
       expect(data).to.deep.eq(fakeData);
-      expect(provider.readTransaction.callCount).to.equal(1);
-      expect(provider.readTransaction.args[0][0]).to.deep.eq(TEST_READ_TX);
+      expect(provider.readContract.callCount).to.equal(1);
+      expect(provider.readContract.args[0][0]).to.deep.eq(TEST_READ_TX);
     });
 
     it("should throw if provider fails", async () => {
-      provider.readTransaction.rejects(new RpcError("fail"));
+      provider.readContract.rejects(new RpcError("fail"));
 
       await expect(chainReader.readTx(TEST_READ_TX)).to.be.rejectedWith("fail");
     });

--- a/packages/txservice/test/chainreader.spec.ts
+++ b/packages/txservice/test/chainreader.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "@connext/nxtp-utils";
 
 import { cachedPriceMap, ChainReader } from "../src/chainreader";
-import { ChainRpcProvider } from "../src/provider";
+import { RpcProviderAggregator } from "../src/rpcProviderAggregator";
 import { ChainNotSupported, ConfigurationError, ProviderNotConfigured, RpcError } from "../src/shared";
 import * as contractFns from "../src/shared/contracts";
 import {
@@ -30,7 +30,7 @@ const logger = new Logger({
 
 let signer: SinonStubbedInstance<Wallet>;
 let chainReader: ChainReader;
-let provider: SinonStubbedInstance<ChainRpcProvider>;
+let provider: SinonStubbedInstance<RpcProviderAggregator>;
 let context: RequestContext = {
   id: "",
   origin: "",
@@ -40,7 +40,7 @@ let context: RequestContext = {
 /// For core functionality tests, see dispatch.spec.ts and provider.spec.ts.
 describe("ChainReader", () => {
   beforeEach(() => {
-    provider = createStubInstance(ChainRpcProvider);
+    provider = createStubInstance(RpcProviderAggregator);
     signer = createStubInstance(Wallet);
     signer.connect.resolves(true);
 

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -42,6 +42,7 @@ let txDispatch: TransactionDispatch;
 let dispatchCallbacks: DispatchCallbacks;
 let getGasPriceStub: SinonStub;
 let estimateGasStub: SinonStub;
+let getTransactionStub: SinonStub;
 let getTransactionCountStub: SinonStub;
 let sendTransactionStub: SinonStub;
 let getAddressStub: SinonStub;
@@ -60,6 +61,7 @@ const stubAllDispatchMethods = (): void => {
   });
   getAddressStub = stub(txDispatch as any, "getAddress").resolves(signer.address);
   sendTransactionStub = stub(txDispatch as any, "sendTransaction").returns(TEST_TX_RESPONSE);
+  getTransactionStub = stub(txDispatch as any, "getTransaction").resolves([TEST_TX_RESPONSE]);
   getTransactionCountStub = stub(txDispatch as any, "getTransactionCount").resolves(TEST_TX_RESPONSE.nonce);
   getGasPriceStub = stub(txDispatch as any, "getGasPrice").resolves(TEST_FULL_TX.gasPrice);
   estimateGasStub = stub(txDispatch as any, "estimateGas").resolves(TEST_FULL_TX.gasLimit);
@@ -140,25 +142,89 @@ describe("TransactionDispatch", () => {
       (txDispatch as any).inflightBuffer = [stubTx];
     });
 
-    it("should fail if there is a non-timeout tx error", async () => {
+    it("should fail immediately if there is an error attached to tx", async () => {
       stubTx.error = new Error("test error");
       await (txDispatch as any).mineLoop();
-      expect(failStub).callCount(0);
+      // expect(failStub).to.have.been.calledOnceWithExactly(makeChaiReadable(stubTx));
+      expect(failStub.callCount).to.eq(1);
     });
 
-    it("should bump if times out during confirming", async () => {
+    it("should bump and resubmit if timeout occurs while waiting for confirmation", async () => {
       mineStub.onCall(0).rejects(new OperationTimeout());
       mineStub.onCall(1).resolves();
+      getTransactionStub.resolves([
+        {
+          ...TEST_TX_RESPONSE,
+          confirmations: 0,
+        },
+      ]);
+
       await (txDispatch as any).mineLoop();
+
       expect(mineStub.callCount).to.eq(2);
       expect(makeChaiReadable(mineStub.getCall(0).args[0])).to.deep.eq(makeChaiReadable(stubTx));
       expect(makeChaiReadable(mineStub.getCall(1).args[0])).to.deep.eq(makeChaiReadable(stubTx));
       expect(bumpStub).to.have.been.calledOnceWithExactly(stubTx);
       expect(submitStub).to.have.been.calledOnceWithExactly(stubTx);
+      expect(getTransactionStub).to.have.been.calledOnceWithExactly(stubTx);
       expect((txDispatch as any).minedBuffer.length).to.eq(1);
     });
 
-    it("should bump txs in the buffer", async () => {
+    it("should resubmit without bumping if timeout occurs and tx does not exist", async () => {
+      mineStub.onCall(0).rejects(new OperationTimeout());
+      mineStub.onCall(1).resolves();
+      getTransactionStub.resolves([null]);
+
+      await (txDispatch as any).mineLoop();
+
+      expect(mineStub.callCount).to.eq(2);
+      expect(bumpStub.callCount).to.eq(0);
+      expect(submitStub.callCount).to.eq(1);
+      expect(getTransactionStub).to.have.been.calledOnceWithExactly(stubTx);
+      expect((txDispatch as any).minedBuffer.length).to.eq(1);
+    });
+
+    it("should not resubmit if timeout occurs, but tx exists and has 1+ confirmations", async () => {
+      mineStub.onCall(0).rejects(new OperationTimeout());
+      mineStub.onCall(1).resolves();
+      getTransactionStub.resolves([
+        {
+          ...TEST_TX_RESPONSE,
+          confirmations: 1,
+        },
+      ]);
+
+      await (txDispatch as any).mineLoop();
+
+      expect(mineStub.callCount).to.eq(2);
+      expect(bumpStub.callCount).to.eq(0);
+      expect(submitStub.callCount).to.eq(0);
+      expect(getTransactionStub).to.have.been.calledOnceWithExactly(stubTx);
+      expect((txDispatch as any).minedBuffer.length).to.eq(1);
+    });
+
+    it("should not resubmit if insufficient funds error occurs", async () => {
+      // Mine -> Timeout -> Bump+Resubmit -> InsufficientFunds -> Mine (NO Resubmit) -> Success.
+      mineStub.onCall(0).rejects(new OperationTimeout());
+      getTransactionStub.resolves([
+        {
+          ...TEST_TX_RESPONSE,
+          confirmations: 0,
+        },
+      ]);
+      submitStub.onCall(0).rejects(new TransactionReverted(TransactionReverted.reasons.InsufficientFunds));
+      mineStub.onCall(1).resolves();
+
+      await (txDispatch as any).mineLoop();
+
+      expect(mineStub.callCount).to.eq(2);
+      expect(bumpStub.callCount).to.eq(1);
+      expect(submitStub.callCount).to.eq(1);
+      expect(getTransactionStub).to.have.been.calledOnceWithExactly(stubTx);
+      expect((txDispatch as any).minedBuffer.length).to.eq(1);
+    });
+
+    it("should handle multiple txs in the buffer one at a time", async () => {
       const stubTx1 = { ...stubTx, data: "0xa" };
       const stubTx2 = { ...stubTx, data: "0xb" };
       const stubTx3 = { ...stubTx, data: "0xc" };
@@ -190,7 +256,30 @@ describe("TransactionDispatch", () => {
       expect((txDispatch as any).minedBuffer.length).to.deep.eq(1);
     });
 
-    it("should assign errors on tx resubmit", async () => {
+    it("should assign error to transaction on mine fail", async () => {
+      const stubTx1 = { ...stubTx, data: "0xa" };
+      (txDispatch as any).inflightBuffer = [stubTx1];
+      const error = new Error("test");
+      mineStub.rejects(error);
+      getTransactionStub.resolves([
+        {
+          ...TEST_TX_RESPONSE,
+          confirmations: 0,
+        },
+      ]);
+
+      await (txDispatch as any).mineLoop();
+
+      const readableStubTx = makeChaiReadable(stubTx1);
+      expect(mineStub).to.have.been.calledOnceWithExactly(readableStubTx);
+      expect(stubTx1.error).to.eq(error);
+      expect(failStub).to.have.been.calledOnceWithExactly(readableStubTx);
+      // Should have taken tx out of the buffer, but not added to minedBuffer.
+      expect((txDispatch as any).inflightBuffer).to.deep.eq([]);
+      expect((txDispatch as any).minedBuffer).to.deep.eq([]);
+    });
+
+    it("should assign error to onchain transaction object on resubmit fail", async () => {
       const stubTx1 = { ...stubTx, data: "0xa" };
       (txDispatch as any).inflightBuffer = [stubTx1];
       mineStub.rejects(new OperationTimeout());
@@ -219,7 +308,7 @@ describe("TransactionDispatch", () => {
       expect(failStub.getCall(0).args[0].error).to.deep.eq(mineError);
     });
 
-    it("should mine a tx and remove it from the buffer", async () => {
+    it("happy: should mine a tx and remove it from the buffer", async () => {
       await (txDispatch as any).mineLoop();
       expect(mineStub).to.have.been.calledOnceWithExactly(stubTx);
       expect((txDispatch as any).inflightBuffer.length).to.eq(0);

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -5,7 +5,7 @@ import { expect } from "@connext/nxtp-utils";
 
 import { ChainConfig, DEFAULT_CHAIN_CONFIG } from "../src/config";
 import { DispatchCallbacks, TransactionDispatch } from "../src/dispatch";
-import { ChainRpcProvider } from "../src/provider";
+import { RpcProviderAggregator } from "../src/rpcProviderAggregator";
 import {
   OnchainTransaction,
   BadNonce,
@@ -102,8 +102,8 @@ describe("TransactionDispatch", () => {
       confirmationTimeout: 10_000,
     };
 
-    Sinon.stub(ChainRpcProvider.prototype as any, "syncProviders").resolves();
-    Sinon.stub(ChainRpcProvider.prototype as any, "setBlockPeriod").resolves();
+    Sinon.stub(RpcProviderAggregator.prototype as any, "syncProviders").resolves();
+    Sinon.stub(RpcProviderAggregator.prototype as any, "setBlockPeriod").resolves();
 
     // NOTE: This will start dispatch with NO loops running. We will start the loops manually in unit tests below.
     txDispatch = new TransactionDispatch(logger, TEST_SENDER_CHAIN_ID, chainConfig, signer, dispatchCallbacks, false);
@@ -497,12 +497,6 @@ describe("TransactionDispatch", () => {
 
     it("should throw if the transaction is already finished", async () => {
       mockTransactionState.didFinish = true;
-      await expect((txDispatch as any).submit(transaction)).to.eventually.be.rejectedWith(TransactionProcessingError);
-    });
-
-    it("should throw if it's a second attempt and gas price hasn't been increased", async () => {
-      const txResponse: providers.TransactionResponse = { ...TEST_TX_RESPONSE };
-      transaction.responses = [txResponse];
       await expect((txDispatch as any).submit(transaction)).to.eventually.be.rejectedWith(TransactionProcessingError);
     });
 

--- a/packages/txservice/test/rpcProviderAggregator.spec.ts
+++ b/packages/txservice/test/rpcProviderAggregator.spec.ts
@@ -272,24 +272,24 @@ describe("RpcProviderAggregator", () => {
     });
   });
 
-  describe("#readTransaction", () => {
-    it("happy: should read the transaction", async () => {
+  describe("#readContract", () => {
+    it("happy: should perform contract read method as given", async () => {
       const fakeData = getRandomBytes32();
       signer.call.resolves(fakeData);
 
-      const result = await chainProvider.readTransaction(TEST_READ_TX);
+      const result = await chainProvider.readContract(TEST_READ_TX);
 
       expect(signer.call.callCount).to.equal(1);
       expect(signer.call.getCall(0).args[0]).to.deep.equal(TEST_READ_TX);
       expect(result).to.be.eq(fakeData);
     });
 
-    it("should return error result if the signer readTransaction call throws", async () => {
+    it("should return error result if the signer readContract call throws", async () => {
       const testError = new Error("test error");
       signer.call.rejects(testError);
 
       // The error.context.error is the "test error" thrown by the signer.call.
-      await expect(chainProvider.readTransaction(TEST_READ_TX)).to.be.rejectedWith(TransactionReadError);
+      await expect(chainProvider.readContract(TEST_READ_TX)).to.be.rejectedWith(TransactionReadError);
     });
 
     it("should execute with provider if no signer available", async () => {
@@ -297,7 +297,7 @@ describe("RpcProviderAggregator", () => {
       (chainProvider as any).signer = undefined;
       coreSyncProvider.call.resolves(fakeData);
 
-      const result = await chainProvider.readTransaction(TEST_READ_TX);
+      const result = await chainProvider.readContract(TEST_READ_TX);
 
       expect(signer.call.callCount).to.equal(0);
       expect(coreSyncProvider.call.callCount).to.equal(1);


### PR DESCRIPTION
## The Problem

Problem assessment thread: https://discord.com/channels/454734546869551114/860482380321652766/922567480080232500

TL;DR:
- A gas spike happened, we couldn't bump over hard maximum and resubmit.
- A tx "disappeared", meaning the blockade nonce had no transaction.... and since we had bumped over maximum gas, we threw an error. What we should have done is resubmitted at the same gas price since the transaction didn't actually exist on chain!*
- A reboot fixed it, but we shouldn't rely on reboots, especially if we have 64 other txs in the queue.

*(*Idk how it's possible, but it happens. Maybe providers don't broadcast a tx properly, a reorg occurs, geth pending tx pool overflows, who knows? But if I check the tx hash on tenderly, I can see that that tx does not exist, even though the logs say it *was* sent to chain.)*

## The Solution

Timeout handling logic was improved. Some of this logic was pre-existing, but here's the whole flow for timeouts now:
- If mine OperationTimeout occurs, we now check to make sure the transaction *does* indeed exist on chain.
  - If it does not exist:
    - Check to make sure the signer's onchain *mined* transaction count (nonce) hasn't surpassed this transaction's nonce. If it has, this indicates the transaction was replaced by another tx, and we throw TransactionBackfilled (should I make this TransactionReplaced?).
    - If this nonce is still the blockade, we should resubmit immediately *without* bumping gas, as the transaction does not exist.
      (- If for some reason the transaction *does actually exist* we will get back a BadNonce error, which is now treated the same as an OperationTimeout.)
  - If transaction *does* exist...
    - and it has 1+ confirmations? Circle back to mine() and get the receipt!
    - and it has 0 confirmations? Bump and resubmit.

**Main change here: we now only bump gas price before resubmit if we can confirm the transaction does in fact exist on chain and hasn't received any confirmations.**

I also added more unit test code coverage for this method.

## Checklist

- [ ] Handle the transaction replaced code branch/path in unit tests for this method
- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
