### PR TITLE
[sdk] Resort to using router network if gelato fails; set default useRelayers = false

### DIFF
--- a/packages/sdk/src/error.ts
+++ b/packages/sdk/src/error.ts
@@ -537,3 +537,28 @@ export class FulfillTimeout extends FulfillError {
     );
   }
 }
+
+/**
+ * @classdesc Thrown when no responses to meta tx request in some timeframe
+ */
+export class InvalidRelayerFee extends FulfillError {
+  static getMessage(transactionId: string, chainId: number) {
+    return `Relayer fee cannot be zero when using relayers for ${transactionId} on chain ${chainId}`;
+  }
+
+  constructor(
+    public readonly transactionId: string,
+    public readonly chainId: number,
+    public readonly context: any = {},
+  ) {
+    super(
+      InvalidRelayerFee.getMessage(transactionId, chainId),
+      {
+        transactionId,
+        chainId,
+        ...context,
+      },
+      InvalidRelayerFee.type,
+    );
+  }
+}

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -1000,8 +1000,8 @@ export class NxtpSdkBase {
     params: Omit<TransactionPreparedEvent, "caller">,
     fulfillSignature: string,
     decryptedCallData: string,
-    relayerFee = "0",
-    _useRelayers = false,
+    relayerFee: string,
+    useRelayers = true,
   ): Promise<{
     transactionResponse?: { transactionHash: string; chainId: number };
     transactionRequest?: providers.TransactionRequest;
@@ -1011,7 +1011,6 @@ export class NxtpSdkBase {
       undefined,
       params.txData.transactionId,
     );
-    const useRelayers = _useRelayers && BigNumber.from(relayerFee).gt(0);
     this.logger.info("Method started", requestContext, methodContext, { params, useRelayers });
     const transactionId = params.txData.transactionId;
 

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -56,7 +56,6 @@ import {
   InvalidParamStructure,
   FulfillTimeout,
   NotEnoughAmount,
-  InvalidRelayerFee,
 } from "./error";
 import {
   TransactionManager,

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -1033,10 +1033,6 @@ export class NxtpSdkBase {
 
     const { txData } = params;
 
-    if (useRelayers && BigNumber.from(relayerFee).isZero()) {
-      throw new InvalidRelayerFee(transactionId, txData.receivingChainId);
-    }
-
     if (!this.config.chainConfig[txData.sendingChainId]) {
       throw new ChainNotConfigured(txData.sendingChainId, Object.keys(this.config.chainConfig));
     }


### PR DESCRIPTION
## The Problem

- for loop retries 3 times... but if it fails the first time, gelatoSuccess is false, so it just throws right away lol
- default relayer fee is 0, and useRelayers default is true... we should not be using relayers if we use the default value of "0"
- we should fall back to using router network if gelato fails

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
