### PR TITLE
[sdk] allow passing in no amount for getEstimateReceiverAmount

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -207,7 +207,7 @@ export class NxtpSdk {
    * @returns Gas fee for router transfer in sending token
    */
   public async getEstimateReceiverAmount(params: {
-    amount: string;
+    amount?: string;
     sendingChainId: number;
     sendingAssetId: string;
     receivingChainId: number;


### PR DESCRIPTION
`getEstimateReceiverAmount` should be usable without specifying an amount - so fees can be estimated right away.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
