### PR TITLE
Use skip polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+- [sdk] Start polling when a transaction is prepared, and stop when final active transaction is completed
+- [integration] Test with ERC20 and with `skipPolling = true`
+
 ## 0.1.9
 
 - [router] Use correct chain for gas fee calc for cancel

--- a/packages/integration/test/integration.spec.ts
+++ b/packages/integration/test/integration.spec.ts
@@ -81,7 +81,22 @@ describe("Integration", () => {
 
   const tokenReceiving = new Contract(erc20Address, TestTokenABI, sugarDaddy.connect(receivingChainProvider));
 
-  const setupTest = async (sendingTokenAddress: string, receivingTokenAddress: string): Promise<void> => {
+  const setupTest = async (
+    sendingTokenAddress: string,
+    receivingTokenAddress: string,
+    skipPolling = false,
+  ): Promise<void> => {
+    if (skipPolling) {
+      // reset user sdk
+      userSdk = new NxtpSdk({
+        chainConfig,
+        signer: userWallet.connect(sendingChainProvider),
+        logger: new Logger({ name: "IntegrationTest", level: process.env.LOG_LEVEL ?? "silent" }),
+        network: "local",
+        skipPolling,
+      });
+    }
+
     const tokenAddressSending = sendingTokenAddress;
     const tokenAddressReceiving = receivingTokenAddress;
 
@@ -274,7 +289,7 @@ describe("Integration", () => {
     });
   });
 
-  it.only("should send ERC20 tokens", async function () {
+  it("should send ERC20 tokens", async function () {
     this.timeout(120_000);
 
     const sendingAssetId = erc20Address;
@@ -292,6 +307,17 @@ describe("Integration", () => {
     const receivingAssetId = AddressZero;
 
     await setupTest(sendingAssetId, receivingAssetId);
+
+    await test(sendingAssetId, receivingAssetId);
+  });
+
+  it("should work when user sdk isnt polling", async function () {
+    this.timeout(120_000);
+
+    const sendingAssetId = erc20Address;
+    const receivingAssetId = erc20Address;
+
+    await setupTest(sendingAssetId, receivingAssetId, true);
 
     await test(sendingAssetId, receivingAssetId);
   });

--- a/packages/integration/test/integration.spec.ts
+++ b/packages/integration/test/integration.spec.ts
@@ -300,7 +300,7 @@ describe("Integration", () => {
     await test(sendingAssetId, receivingAssetId);
   });
 
-  it("should send Native tokens", async function () {
+  it.skip("should send Native tokens", async function () {
     this.timeout(120_000);
 
     const sendingAssetId = AddressZero;

--- a/packages/sdk/src/subgraph/subgraph.ts
+++ b/packages/sdk/src/subgraph/subgraph.ts
@@ -146,6 +146,10 @@ export class Subgraph {
     }
   }
 
+  public getActiveTransactionIds(): string[] {
+    return [...this.activeTxs.keys()];
+  }
+
   public stopPolling(): void {
     if (this.pollingLoop != null) {
       clearInterval(this.pollingLoop);
@@ -159,7 +163,7 @@ export class Subgraph {
         const { methodContext, requestContext } = createLoggingContext("pollingLoop");
         try {
           await this.getActiveTransactions();
-        } catch (err) {
+        } catch (err: any) {
           this.logger.error("Error in subgraph loop", requestContext, methodContext, err);
         }
       }, this.pollInterval);
@@ -513,7 +517,7 @@ export class Subgraph {
 
           const activeFlattened = activeTxs.flat().filter((x) => !!x) as ActiveTransaction[];
           return activeFlattened;
-        } catch (e) {
+        } catch (e: any) {
           errors.set(chainId, e);
           this.logger.error("Error getting active transactions", requestContext, methodContext, jsonifyError(e), {
             chainId,


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- `skipPolling` requires the UI to trigger polling when there are active transactions

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- start polling when a transaction is `prepare`d, stop polling when there are 0 active transactions and the final tx is completed

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
