### PR TITLE
[txservice] Rewind nonce if transaction fails and was never mined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- [txservice] Rewind nonce if transaction fails and was never mined
 - [sdk] Return subgraph query in generic query method
 - [router] Track bids in memory to only bid 150% of available liquidity
 

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -588,6 +588,9 @@ describe("TransactionDispatch", () => {
     });
 
     it("should rewind the local nonce if the transaction has an error but was never mined", async () => {
+      const expectedNonce = 100;
+      (txDispatch as any).nonce = 123456789;
+      getTransactionCountStub.resolves(expectedNonce);
       submitStub.callsFake(async (transaction: OnchainTransaction) => {
         stub(transaction, "didSubmit").get(() => mockTransactionState.didSubmit);
         // Transaction was not mined or confirmed.
@@ -599,6 +602,7 @@ describe("TransactionDispatch", () => {
         transaction.error = new TransactionReverted("fail");
       });
       await expect(txDispatch.send(TEST_TX, context)).to.be.rejectedWith("fail");
+      expect((txDispatch as any).nonce).to.eq(expectedNonce);
     });
   });
 

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -589,9 +589,11 @@ describe("TransactionDispatch", () => {
 
     it("should rewind the local nonce if the transaction has an error but was never mined", async () => {
       const expectedNonce = 100;
-      (txDispatch as any).nonce = 123456789;
-      getTransactionCountStub.resolves(expectedNonce);
+      (txDispatch as any).nonce = expectedNonce;
+      determineNonceStub.resolves({ nonce: expectedNonce, backfill: false, transactionCount: expectedNonce });
       submitStub.callsFake(async (transaction: OnchainTransaction) => {
+        // Now we set the local nonce to a bunk value in order to make sure it gets replaced (with expectedNonce) later.
+        (txDispatch as any).nonce = 123456789;
         stub(transaction, "didSubmit").get(() => mockTransactionState.didSubmit);
         // Transaction was not mined or confirmed.
         stub(transaction, "didMine").get(() => false);

--- a/packages/txservice/test/dispatch.spec.ts
+++ b/packages/txservice/test/dispatch.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber, providers, utils, Wallet } from "ethers";
+import { BigNumber, utils, Wallet } from "ethers";
 import Sinon, { createStubInstance, reset, restore, SinonStub, SinonStubbedInstance, stub } from "sinon";
 import { getRandomBytes32, Logger, mkAddress, txReceiptMock } from "@connext/nxtp-utils";
 import { expect } from "@connext/nxtp-utils";
@@ -527,7 +527,7 @@ describe("TransactionDispatch", () => {
       expect(submitStub.callCount).to.eq(1);
     });
 
-    it("should throw if getGas fails", async () => {
+    it("should throw if getGasPrice fails", async () => {
       getGasPriceStub.rejects(new RpcError("fail"));
       await expect(txDispatch.send(TEST_TX, context)).to.be.rejectedWith("fail");
     });
@@ -574,9 +574,32 @@ describe("TransactionDispatch", () => {
 
     it.skip("should wait until transaction is mined/confirmed", async () => {});
 
-    it.skip("should throw if the transaction has an error after mine/confirm", async () => {});
+    it("should throw if the transaction has an error after mine or confirm", async () => {
+      submitStub.callsFake(async (transaction: OnchainTransaction) => {
+        stub(transaction, "didSubmit").get(() => mockTransactionState.didSubmit);
+        // Transaction never went to confirmation step, so it's not considered finished.
+        stub(transaction, "didFinish").get(() => false);
+        transaction.responses = [TEST_TX_RESPONSE];
+        transaction.receipt = TEST_TX_RECEIPT;
+        // Added an error here.
+        transaction.error = new TransactionReverted("fail");
+      });
+      await expect(txDispatch.send(TEST_TX, context)).to.be.rejectedWith("fail");
+    });
 
-    it.skip("should throw if the transaction has no receipt after mine/confirm", async () => {});
+    it("should rewind the local nonce if the transaction has an error but was never mined", async () => {
+      submitStub.callsFake(async (transaction: OnchainTransaction) => {
+        stub(transaction, "didSubmit").get(() => mockTransactionState.didSubmit);
+        // Transaction was not mined or confirmed.
+        stub(transaction, "didMine").get(() => false);
+        stub(transaction, "didFinish").get(() => false);
+        transaction.responses = [TEST_TX_RESPONSE];
+        transaction.receipt = TEST_TX_RECEIPT;
+        // Added an error here.
+        transaction.error = new TransactionReverted("fail");
+      });
+      await expect(txDispatch.send(TEST_TX, context)).to.be.rejectedWith("fail");
+    });
   });
 
   describe("#submit", () => {


### PR DESCRIPTION
## The Problem

- If a tx at nonce X failed but never got mined (possibly indicating it was not sent correctly), we throw... but never backfill at that nonce! Thus causing a blockade.

## The Solution

- When a tx errors out, we check to see if it got mined properly. If not, then we reset the local nonce to the value of this tx's nonce. Then, on the next transaction, we will backfill.
  - Worst case scenario, if the tx *does* end up getting mined even after resetting local nonce, on the next sent transaction we will just end up favoring the signer's current transactionCount over the local nonce (since we prefer whichever number is higher!).
  - Only problem with this diff is that we're resetting the local nonce but not actually guaranteeing that we send a backfill... meaning that we have to *hope* that another transaction comes in soon. Regardless, it is definitely an improvement and better solution than we had previously (which was no solution for this edge case at all...)
  

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
