### PR TITLE
[sdk] Preferred routers should be null or empty list

### DIFF
--- a/packages/sdk/test/unit/sdkBase.spec.ts
+++ b/packages/sdk/test/unit/sdkBase.spec.ts
@@ -481,6 +481,15 @@ describe("NxtpSdkBase", () => {
       });
     });
 
+    describe("should work with empty list of preferredRouters", () => {
+      const { crossChainParams } = getMock({ preferredRouters: [] });
+      it.only("empty preferred routers", async () => {
+        console.log("crossChainParams", crossChainParams);
+        const ret = await sdk.getTransferQuote(crossChainParams);
+        console.log("ret", ret);
+      });
+    });
+
     describe("should error if invalid config", () => {
       it("unknown sendingChainId", async () => {
         const { crossChainParams } = getMock({ sendingChainId: 1400 });


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Closes #712  -- reported by the coin hippo team.

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Allow accepting an empty list

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
