### PR TITLE
[sdk] Return subgraph query; tidy up method headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- [sdk] Return subgraph query in generic query method
+
 ## 0.1.11
 
 - [contracts] Add ability to one-off verify contracts via hardhat

--- a/packages/router/test/globalTestHook.ts
+++ b/packages/router/test/globalTestHook.ts
@@ -51,6 +51,7 @@ export const mochaHooks = {
     txServiceMock.calculateGasFeeInReceivingToken.resolves(BigNumber.from(100));
     txServiceMock.calculateGasFeeInReceivingTokenForFulfill.resolves(BigNumber.from(120));
     txServiceMock.getTokenPrice.resolves(BigNumber.from(1));
+    txServiceMock.getGasEstimate.resolves(BigNumber.from(24001));
 
     messagingMock = createStubInstance(RouterNxtpNatsMessagingService);
 

--- a/packages/router/test/lib/operations/metaTx.spec.ts
+++ b/packages/router/test/lib/operations/metaTx.spec.ts
@@ -1,14 +1,11 @@
+import { BigNumber, constants } from "ethers";
 import {
   expect,
-  invariantDataMock,
   txReceiptMock,
   createLoggingContext,
   mkBytes32,
-  getNtpTimeSeconds,
-  MetaTxPayload,
   MetaTxType,
   mkAddress,
-  MetaTxTypes,
   MetaTxFulfillPayload,
   txDataMock,
   sigMock,
@@ -18,17 +15,14 @@ import {
   prepareParamsMock,
   fulfillParamsMock,
   cancelParamsMock,
-  MetaTxPayloads,
 } from "@connext/nxtp-utils";
-import { BigNumber, constants } from "ethers";
 
-import * as SharedHelperFns from "../../../src/lib/helpers/shared";
 import { callDataMock, configMock, relayerFeeMock } from "../../utils";
 import { sendMetaTx } from "../../../src/lib/operations/metaTx";
 import { MetaTxInput } from "../../../src/lib/entities";
 import { NotAllowedFulfillRelay, NotEnoughRelayerFee } from "../../../src/lib/errors";
-import { SinonStub, stub } from "sinon";
 import { contractWriterMock, txServiceMock } from "../../globalTestHook";
+import { SinonStub } from "sinon";
 
 const { requestContext } = createLoggingContext("TEST", undefined, mkBytes32("0xabc"));
 
@@ -81,6 +75,10 @@ const metaTxInputMock = <T extends MetaTxType>(type: T): MetaTxInput => {
 };
 
 describe("Meta Tx Operation", () => {
+  beforeEach(() => {
+    Object.values(contractWriterMock).forEach((method: any) => (method as SinonStub).resetHistory());
+  });
+
   it("should error if invalid data", async () => {
     const metaTxMock = metaTxInputMock("Fulfill");
     metaTxMock.chainId = undefined;

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -528,7 +528,9 @@ export class NxtpSdk {
    * in-sync subgraphs if necessary.
    *
    * @param chainId - Chain that the subgraph(s) are on.
-   * @param query - Query string to send to the subgraph(s).
+   * @param query - GraphQL query string to send to the subgraph(s). (For more information
+   * on writing your own queries, see: https://graphql.org/learn/)
+   *
    * @returns Query response from the (first) subgraph that responded.
    */
   public async querySubgraph(chainId: number, query: string): Promise<any> {

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -1156,7 +1156,7 @@ export class NxtpSdkBase {
   }
 
   public async querySubgraph(chainId: number, query: string): Promise<any> {
-    this.subgraph.query(chainId, query);
+    return this.subgraph.query(chainId, query);
   }
 
   /**

--- a/packages/sdk/test/unit/sdk.spec.ts
+++ b/packages/sdk/test/unit/sdk.spec.ts
@@ -29,7 +29,7 @@ import {
   ChainNotConfigured,
   FulfillTimeout,
 } from "../../src/error";
-import { CrossChainParams, NxtpSdkEvent, NxtpSdkEventPayloads, NxtpSdkEvents } from "../../src";
+import { CrossChainParams, NxtpSdkEvents } from "../../src";
 import { TransactionManager } from "../../src/transactionManager/transactionManager";
 import { NxtpSdkBase } from "../../src/sdkBase";
 import * as TransactionManagerHelperFns from "../../src/transactionManager/transactionManager";
@@ -589,9 +589,12 @@ describe("NxtpSdk", () => {
   });
 
   describe("#querySubgraph", () => {
-    it("happy querySubgraph", async () => {
-      await sdk.querySubgraph(sendingChainId, "");
-      expect(sdkBase.querySubgraph).to.be.calledOnceWithExactly(sendingChainId, "");
+    it("happy", async () => {
+      const testQueryResult = "test-123";
+      sdkBase.querySubgraph.resolves(testQueryResult);
+      const res = await sdk.querySubgraph(sendingChainId, "test");
+      expect(sdkBase.querySubgraph).to.have.been.calledOnceWithExactly(sendingChainId, "test");
+      expect(res).to.eq(testQueryResult);
     });
   });
 

--- a/packages/sdk/test/unit/sdkBase.spec.ts
+++ b/packages/sdk/test/unit/sdkBase.spec.ts
@@ -7,14 +7,12 @@ import {
   VariantTransactionData,
   AuctionBid,
   Logger,
-  DEFAULT_GAS_ESTIMATES,
   requestContextMock,
-  calculateExchangeAmount,
   NATS_AUTH_URL_LOCAL,
 } from "@connext/nxtp-utils";
 import { expect } from "chai";
 import { Wallet, constants, BigNumber } from "ethers";
-import Sinon, { createStubInstance, reset, restore, SinonStub, SinonStubbedInstance, stub } from "sinon";
+import { createStubInstance, reset, restore, SinonStub, SinonStubbedInstance, stub } from "sinon";
 
 import { MAX_SLIPPAGE_TOLERANCE, MIN_SLIPPAGE_TOLERANCE } from "../../src/sdk";
 import * as TransactionManagerHelperFns from "../../src/transactionManager/transactionManager";
@@ -44,7 +42,7 @@ import {
 } from "../../src/error";
 import { getAddress, keccak256, parseEther } from "ethers/lib/utils";
 import { CrossChainParams, NxtpSdkEvents, HistoricalTransactionStatus, ApproveParams } from "../../src";
-import { createSubgraphEvts, Subgraph } from "../../src/subgraph/subgraph";
+import { Subgraph } from "../../src/subgraph/subgraph";
 import { getMinExpiryBuffer, getMaxExpiryBuffer } from "../../src/utils";
 import { TransactionManager } from "../../src/transactionManager/transactionManager";
 import { NxtpSdkBase } from "../../src/sdkBase";
@@ -1337,8 +1335,11 @@ describe("NxtpSdkBase", () => {
 
   describe("#querySubgraph", () => {
     it("happy", async () => {
-      sdk.querySubgraph(sendingChainId, "test");
+      const testQueryResult = "test-123";
+      subgraph.query.resolves(testQueryResult);
+      const res = await sdk.querySubgraph(sendingChainId, "test");
       expect(subgraph.query).to.be.calledOnceWithExactly(sendingChainId, "test");
+      expect(res).to.eq(testQueryResult);
     });
   });
 

--- a/packages/utils/src/fallbackSubgraph.ts
+++ b/packages/utils/src/fallbackSubgraph.ts
@@ -125,9 +125,9 @@ export class FallbackSubgraph<T extends SubgraphSdk> {
    * @returns any, whatever the expected GraphQL response is.
    */
   public async query(query: string): Promise<any> {
-    this.request((_, url) => {
+    return this.request((_, url) => {
       return request(url, query);
-    });
+    }, false);
   }
 
   /**


### PR DESCRIPTION
## The Problem

- We weren't actually returning the query result in the 'generic' subgraph query before 🤦‍♂️ 

## The Solution

- Now we do

- Also did a bit of tidying up, the inconsistent fn headers were bothering me.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
