### PR TITLE
[sdk] Sdk sendTransaction helper

### DIFF
--- a/packages/integration/test/utils/sdkAgent.ts
+++ b/packages/integration/test/utils/sdkAgent.ts
@@ -153,7 +153,7 @@ export class SdkAgent {
     });
 
     // Create sdk
-    const sdk = new NxtpSdk({
+    const sdk = await NxtpSdk.create({
       chainConfig,
       signer: connected,
       natsUrl,

--- a/packages/sdk-server/src/config.ts
+++ b/packages/sdk-server/src/config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 
 import { Type, Static } from "@sinclair/typebox";
 import { ajv, Logger, parseProviders, TChainId } from "@connext/nxtp-utils";
-import { NetworkSchema, LogLevelScehma, SdkConfigParams, SdkChainConfig } from "@connext/nxtp-sdk";
+import { NetworkSchema, LogLevelScehma, SdkChainConfig, SdkBaseConfigParams } from "@connext/nxtp-sdk";
 import { Wallet } from "ethers";
 
 export const SdkServerChainConfigSchema = Type.Record(
@@ -29,7 +29,7 @@ export const NxtpSdkServerConfigSchema = Type.Object({
 
 export type NxtpSdkServerConfig = Static<typeof NxtpSdkServerConfigSchema>;
 
-export const getConfig = (): SdkConfigParams => {
+export const getConfig = (): SdkBaseConfigParams => {
   let configFile: any = {};
 
   try {
@@ -84,9 +84,10 @@ export const getConfig = (): SdkConfigParams => {
   //   provider:
   // };
 
-  const config: SdkConfigParams = {
+  const config: SdkBaseConfigParams = {
     chainConfig: chainConfig,
     signer,
+    signerAddress: signer.getAddress(),
     messagingSigner,
     logger: new Logger({ name: "sdk-server", level: serverConfig.logLevel }),
     network: serverConfig.network,

--- a/packages/sdk-server/src/config.ts
+++ b/packages/sdk-server/src/config.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
 
 import { Type, Static } from "@sinclair/typebox";
-import { ajv, Logger, TChainId } from "@connext/nxtp-utils";
-import { SdkBaseConfigParams, NetworkSchema, LogLevelScehma, SdkBaseChainConfigParams } from "@connext/nxtp-sdk";
+import { ajv, Logger, parseProviders, TChainId } from "@connext/nxtp-utils";
+import { NetworkSchema, LogLevelScehma, SdkConfigParams, SdkChainConfig } from "@connext/nxtp-sdk";
 import { Wallet } from "ethers";
 
 export const SdkServerChainConfigSchema = Type.Record(
@@ -29,7 +29,7 @@ export const NxtpSdkServerConfigSchema = Type.Object({
 
 export type NxtpSdkServerConfig = Static<typeof NxtpSdkServerConfigSchema>;
 
-export const getConfig = (): SdkBaseConfigParams => {
+export const getConfig = (): SdkConfigParams => {
   let configFile: any = {};
 
   try {
@@ -69,10 +69,10 @@ export const getConfig = (): SdkBaseConfigParams => {
     ? Wallet.fromMnemonic(serverConfig.messagingMnemonic)
     : undefined;
 
-  const chainConfig: SdkBaseChainConfigParams = {};
+  const chainConfig: SdkChainConfig = {};
   Object.entries(serverConfig.chainConfig).forEach(([chainId, config]) => {
     chainConfig[parseInt(chainId)] = {
-      providers: config.providers,
+      providers: parseProviders(config.providers),
       transactionManagerAddress: config.transactionManagerAddress,
       priceOracleAddress: config.priceOracleAddress,
       subgraph: config.subgraph,
@@ -84,9 +84,8 @@ export const getConfig = (): SdkBaseConfigParams => {
   //   provider:
   // };
 
-  const config: SdkBaseConfigParams = {
+  const config: SdkConfigParams = {
     chainConfig: chainConfig,
-    signerAddress: signer.getAddress(),
     signer,
     messagingSigner,
     logger: new Logger({ name: "sdk-server", level: serverConfig.logLevel }),

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -502,6 +502,7 @@ export class NxtpSdk {
     this.sdkBase.changeInjectedSigner(signer);
   }
 
+  /// Event methods
   /**
    * Turns off all listeners and disconnects messaging from the SDK.
    */
@@ -510,7 +511,6 @@ export class NxtpSdk {
     this.sdkBase.removeAllListeners();
   }
 
-  // Listener methods
   /**
    * Attaches a callback to the emitted event
    *

--- a/packages/sdk/src/sdkBase.ts
+++ b/packages/sdk/src/sdkBase.ts
@@ -75,7 +75,7 @@ import {
   GetTransferQuote,
   ApproveParams,
   SdkChainConfig,
-  SdkConfigParams,
+  SdkBaseConfigParams,
 } from "./types";
 import {
   getTransactionId,
@@ -132,12 +132,7 @@ export class NxtpSdkBase {
   private readonly auctionResponseEvt = createMessagingEvt<AuctionResponse>();
   private readonly statusResponseEvt = createMessagingEvt<StatusResponse>();
 
-  constructor(
-    private readonly config: Omit<SdkConfigParams, "signer"> & {
-      signer?: Signer;
-      signerAddress: Promise<string>;
-    },
-  ) {
+  constructor(private readonly config: SdkBaseConfigParams) {
     const {
       chainConfig,
       messagingSigner,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -15,6 +15,7 @@ import {
 } from "@connext/nxtp-utils";
 import { Type, Static } from "@sinclair/typebox";
 import { providers, Signer } from "ethers";
+
 import { NxtpSdkBase } from "./sdkBase";
 
 export const SdkBaseChainConfigSchema = Type.Record(

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -80,8 +80,13 @@ type CoreSdkConfigParams = {
   skipPolling?: boolean;
   chainData?: Map<string, ChainData>;
 };
+
 export type SdkConfigParams = {
   chainConfig: SdkChainConfig;
+} & CoreSdkConfigParams;
+export type SdkBaseConfigParams = Omit<SdkConfigParams, "signer"> & {
+  signer?: Signer;
+  signerAddress: Promise<string>;
 } & CoreSdkConfigParams;
 export type InputSdkConfigParams = {
   chainConfig: InputSdkChainConfig;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -15,6 +15,7 @@ import {
 } from "@connext/nxtp-utils";
 import { Type, Static } from "@sinclair/typebox";
 import { providers, Signer } from "ethers";
+import { NxtpSdkBase } from "./sdkBase";
 
 export const SdkBaseChainConfigSchema = Type.Record(
   Type.Number(),
@@ -45,33 +46,30 @@ export const LogLevelScehma = Type.Union([
 
 export const NetworkSchema = Type.Union([Type.Literal("local"), Type.Literal("testnet"), Type.Literal("mainnet")]);
 
-// export const SdkBaseConfigSchema = Type.Object({
-//   chainConfig: SdkBaseChainConfigParams,
-//   signerAddress: Type.Promise(Type.String()),
-//   signer: Type.Optional(Type.Any(Signer)),
-//   messagingSigner: Type.Optional(Type.Any(Signer)),
-//   logger: Type.Optional(Type.Any(Logger)),
-//   network: Type.Optional(Type.Enum(NetworkEnum)),
-//   natsUrl: Type.Optional(Type.String()),
-//   authUrl: Type.Optional(Type.String()),
-//   messaging: Type.Optional(Type.Any(UserNxtpNatsMessagingService)),
-//   skipPolling: Type.Optional(Type.Boolean()),
-// });
-
-// export type SdkBaseConfigParams = Static<typeof SdkBaseConfigSchema>;
-export type SdkBaseChainConfigParams = {
-  [chainId: number]: {
-    providers: string | string[] | { url: string; user?: string; password?: string }[];
-    transactionManagerAddress?: string;
-    priceOracleAddress?: string;
-    subgraph?: string | string[];
-    subgraphSyncBuffer?: number;
+/// MARK - SDK CONFIG
+// Sdk chainConfig core parameters.
+type CoreChainConfigParams = {
+  transactionManagerAddress?: string;
+  priceOracleAddress?: string;
+  subgraph?: string | string[];
+  subgraphSyncBuffer?: number;
+};
+// Internally used chain config.
+export type SdkChainConfig = {
+  [chainId: number]: CoreChainConfigParams & {
+    providers: { url: string; user?: string; password?: string }[];
   };
 };
-export type SdkBaseConfigParams = {
-  chainConfig: SdkBaseChainConfigParams;
-  signerAddress: Promise<string>;
-  signer?: Signer;
+// Backwards compatible chain config, used as input for constructor.
+export type InputSdkChainConfig = {
+  [chainId: number]: CoreChainConfigParams & {
+    providers: string | string[] | { url: string; user?: string; password?: string }[];
+  };
+};
+
+// Core SDK config parameters.
+type CoreSdkConfigParams = {
+  signer: Signer;
   messagingSigner?: Signer;
   logger?: Logger;
   network?: "testnet" | "mainnet" | "local";
@@ -81,6 +79,13 @@ export type SdkBaseConfigParams = {
   skipPolling?: boolean;
   chainData?: Map<string, ChainData>;
 };
+export type SdkConfigParams = {
+  chainConfig: SdkChainConfig;
+} & CoreSdkConfigParams;
+export type InputSdkConfigParams = {
+  chainConfig: InputSdkChainConfig;
+  sdkBase?: NxtpSdkBase;
+} & CoreSdkConfigParams;
 
 export const CrossChainParamsSchema = Type.Object({
   sendingChainId: TChainId,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -87,7 +87,7 @@ export type SdkConfigParams = {
 export type SdkBaseConfigParams = Omit<SdkConfigParams, "signer"> & {
   signer?: Signer;
   signerAddress: Promise<string>;
-} & CoreSdkConfigParams;
+};
 export type InputSdkConfigParams = {
   chainConfig: InputSdkChainConfig;
   sdkBase?: NxtpSdkBase;

--- a/packages/sdk/test/unit/sdk.spec.ts
+++ b/packages/sdk/test/unit/sdk.spec.ts
@@ -7,7 +7,7 @@ import {
   Logger,
   sigMock,
   mkBytes32,
-  chainDataMock,
+  chainDataToMap,
 } from "@connext/nxtp-utils";
 
 import { expect } from "chai";
@@ -42,6 +42,21 @@ const ApproveReq = TxRequest;
 const PrepareReq = { ...TxRequest, data: "0xaaabbb" };
 const FulfillReq = { ...TxRequest, data: "0xaaabbbccc" };
 const CancelReq = { ...TxRequest, data: "0xaaabbbcccddd" };
+
+const chainDataMock = chainDataToMap([
+  {
+    name: "Unit Test Chain 1",
+    chainId: 1337,
+    confirmations: 1,
+    assetId: {},
+  },
+  {
+    name: "Unit Test Chain 2",
+    chainId: 1338,
+    confirmations: 1,
+    assetId: {},
+  },
+]);
 
 describe("NxtpSdk", () => {
   let sdk: NxtpSdk;
@@ -120,7 +135,7 @@ describe("NxtpSdk", () => {
 
     signer.getAddress.resolves(user);
 
-    sdk = new NxtpSdk({
+    sdk = await NxtpSdk.create({
       chainConfig,
       signer,
       sdkBase: sdkBase as any,
@@ -234,7 +249,7 @@ describe("NxtpSdk", () => {
       };
       let error;
       try {
-        const instance = new NxtpSdk({
+        const instance = await NxtpSdk.create({
           chainConfig: _chainConfig,
           signer,
           natsUrl: "http://example.com",
@@ -262,7 +277,7 @@ describe("NxtpSdk", () => {
 
       let error;
       try {
-        const instance = new NxtpSdk({
+        const instance = await NxtpSdk.create({
           chainConfig: _chainConfig,
           signer,
           natsUrl: "http://example.com",
@@ -291,7 +306,7 @@ describe("NxtpSdk", () => {
           priceOracleAddress: priceOracleAddress,
         },
       };
-      const instance = new NxtpSdk({
+      const instance = NxtpSdk.create({
         chainConfig,
         signer,
         natsUrl: "http://example.com",

--- a/packages/sdk/test/unit/sdkBase.spec.ts
+++ b/packages/sdk/test/unit/sdkBase.spec.ts
@@ -9,6 +9,8 @@ import {
   Logger,
   requestContextMock,
   NATS_AUTH_URL_LOCAL,
+  parseProvidersInChainConfig,
+  parseProviders,
 } from "@connext/nxtp-utils";
 import { expect } from "chai";
 import { Wallet, constants, BigNumber } from "ethers";
@@ -41,7 +43,7 @@ import {
   NoBids,
 } from "../../src/error";
 import { getAddress, keccak256, parseEther } from "ethers/lib/utils";
-import { CrossChainParams, NxtpSdkEvents, HistoricalTransactionStatus, ApproveParams } from "../../src";
+import { CrossChainParams, NxtpSdkEvents, HistoricalTransactionStatus, ApproveParams, SdkChainConfig } from "../../src";
 import { Subgraph } from "../../src/subgraph/subgraph";
 import { getMinExpiryBuffer, getMaxExpiryBuffer } from "../../src/utils";
 import { TransactionManager } from "../../src/transactionManager/transactionManager";
@@ -141,12 +143,13 @@ describe("NxtpSdkBase", () => {
     signer.getAddress.resolves(user);
 
     sdk = new NxtpSdkBase({
-      chainConfig,
+      chainConfig: parseProvidersInChainConfig<SdkChainConfig>(chainConfig),
       natsUrl: "http://example.com",
       authUrl: "http://example.com",
       messaging: undefined,
       logger,
       signerAddress: Promise.resolve(user),
+      signer: undefined,
     });
 
     (sdk as any).transactionManager = transactionManager;
@@ -274,7 +277,7 @@ describe("NxtpSdkBase", () => {
     it("should error if transaction manager doesn't exist for chainId", async () => {
       const _chainConfig = {
         [sendingChainId]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
       };
@@ -296,7 +299,7 @@ describe("NxtpSdkBase", () => {
       getDeployedChainIdsForGasFeeStub.returns([sendingChainId, receivingChainId]);
       const _chainConfig = {
         [sendingChainId]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           transactionManagerAddress: sendingChainTxManagerAddress,
         },
       };
@@ -317,11 +320,11 @@ describe("NxtpSdkBase", () => {
     it("happy: constructor, get transactionManager address", async () => {
       const chainConfig = {
         [4]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
         [5]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
       };
@@ -342,11 +345,11 @@ describe("NxtpSdkBase", () => {
     it("happy: constructor, init messaging for each network", async () => {
       const chainConfig = {
         [4]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
         [5]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
       };
@@ -365,11 +368,11 @@ describe("NxtpSdkBase", () => {
     it("happy: constructor, use custom messaging", async () => {
       const chainConfig = {
         [4]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
         [5]: {
-          providers: ["http://----------------------"],
+          providers: parseProviders(["http://----------------------"]),
           subgraph: "http://example.com",
         },
       };

--- a/packages/txservice/src/config.ts
+++ b/packages/txservice/src/config.ts
@@ -1,3 +1,4 @@
+import { parseProviders } from "@connext/nxtp-utils";
 import { Type, Static } from "@sinclair/typebox";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
@@ -173,7 +174,6 @@ export const validateTransactionServiceConfig = (_config: any): TransactionServi
     // Backwards compatibility with specifying only a single provider under the key "provider".
     const _providers: string | string[] | { url: string; user?: string; password?: string }[] =
       chainConfig.providers ?? chainConfig.provider;
-    const providers = typeof _providers === "string" ? [{ url: _providers }] : _providers;
 
     // Remove unused from the mix (such as subgraphs, etc).
     // NOTE: We use CoreChainConfigSchema here because we will format them separately below.
@@ -185,13 +185,7 @@ export const validateTransactionServiceConfig = (_config: any): TransactionServi
     // Merge the default values with the specified chain config.
     config[chainId] = {
       ...sanitizedCoreConfig,
-      providers: providers.map((provider) =>
-        typeof provider === "string"
-          ? {
-              url: provider,
-            }
-          : provider,
-      ),
+      providers: parseProviders(_providers),
     } as ChainConfig;
   });
   ajv.compile(TransactionServiceConfigSchema)(config);

--- a/packages/utils/src/providers.ts
+++ b/packages/utils/src/providers.ts
@@ -3,3 +3,35 @@ import { ethers } from "ethers";
 export const getSimpleRPCPRovider = (rpcUrl: string) => {
   return new ethers.providers.StaticJsonRpcProvider(rpcUrl);
 };
+
+export type RawProviders = string | string[] | { url: string; user?: string; password?: string }[];
+export type ProviderConnectionInfo = { url: string; user?: string; password?: string }[];
+
+// Parse providers into correct format. Used to ensure backwards compatibility.
+export const parseProviders = (providers: RawProviders): ProviderConnectionInfo => {
+  return typeof providers === "string"
+    ? [{ url: providers }]
+    : providers.map((provider) =>
+        typeof provider === "string"
+          ? {
+              url: provider,
+            }
+          : provider,
+      );
+};
+
+// Convenience method for chain config parsing with nested RawProviders.
+export const parseProvidersInChainConfig = <T>(chainConfig: {
+  [chainId: number]: { providers: RawProviders } & T;
+}): { [chainId: number]: { providers: ProviderConnectionInfo } & T } => {
+  const newChainConfig: { [chainId: number]: { providers: ProviderConnectionInfo } & T } = {};
+  Object.keys(chainConfig).forEach((_chainId) => {
+    const chainId = parseInt(_chainId);
+    const config = chainConfig[chainId];
+    newChainConfig[chainId] = {
+      ...config,
+      providers: parseProviders(config.providers),
+    };
+  });
+  return newChainConfig;
+};


### PR DESCRIPTION
## The Problem

SDK was operating on assumption in a lot of places that the injected signer has already been reconnected to the correct providers.

## The Solution

A `sendTransaction` helper in `NxtpSdkBase` connects the injected signer to the providers passed down in the SDK config as soon we intend to execute a transaction. Otherwise, the signer could be connected to the wrong chain ID.

## Checklist

- [x] Update documentation if needed.
- [ ] Update CHANGELOG.md.
