### PR TITLE
Fix logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- [router] Improve logging, add waiting for safe confirmations when handling receiver cancelled
+
 ## 0.1.16
 
 - [router] Use mainnet equivalent for `convertToUsd`

--- a/packages/router/src/bindings/contractReader/index.ts
+++ b/packages/router/src/bindings/contractReader/index.ts
@@ -213,7 +213,13 @@ export const handleSingle = async (
     }
     const preparePayload: PreparePayload = _transaction.payload;
     try {
-      logger.info("Preparing receiver", requestContext, methodContext);
+      logger.info("Preparing receiver", requestContext, methodContext, {
+        senderPrepareTransaction: {
+          transactionHash: senderPrepareReceipt.transactionHash,
+          block: senderPrepareReceipt.blockNumber,
+          confirmations: senderPrepareReceipt.confirmations,
+        },
+      });
       // We need to confirm in the cache that this bid was accepted by the user and we are
       // going through with our commitment to prepare on the receiving chain. The bid may expire in
       // the time it takes to send the prepare transaction, but doing so ensures the cache extends
@@ -400,7 +406,13 @@ export const handleSingle = async (
 
     const fulfillPayload: FulfillPayload = _transaction.payload;
     try {
-      logger.info("Fulfilling sender", requestContext, methodContext);
+      logger.info("Fulfilling sender", requestContext, methodContext, {
+        receiverFulfillTransaction: {
+          transactionHash: receiverFulfillReceipt.transactionHash,
+          block: receiverFulfillReceipt.blockNumber,
+          confirmations: receiverFulfillReceipt.confirmations,
+        },
+      });
       receipt = await fulfill(
         _transaction.crosschainTx.invariant,
         {
@@ -628,8 +640,42 @@ export const handleSingle = async (
       });
       return;
     }
+    if (!_transaction.payload.hashes.receiving?.cancelHash) {
+      logger.warn("No cancel hash for receiving chain", requestContext, methodContext, {
+        hashes: _transaction.payload.hashes,
+      });
+      return;
+    }
+    const chainConfig = config.chainConfig[_transaction.crosschainTx.invariant.receivingChainId];
+    if (!chainConfig) {
+      // this should not happen, this should get checked before this point
+      throw new ContractReaderNotAvailableForChain(_transaction.crosschainTx.invariant.receivingChainId, {
+        methodContext,
+        requestContext,
+      });
+    }
+    const receiverCancelledReceipt = await txService.getTransactionReceipt(
+      _transaction.crosschainTx.invariant.receivingChainId,
+      _transaction.payload.hashes.receiving.cancelHash,
+    );
+    if ((receiverCancelledReceipt?.confirmations ?? 0) < chainConfig.confirmations) {
+      logger.info("Waiting for safe confirmations", requestContext, methodContext, {
+        chainId: _transaction.crosschainTx.invariant.receivingChainId,
+        txHash: _transaction.payload.hashes.receiving.cancelHash,
+        txConfirmations: receiverCancelledReceipt?.confirmations ?? 0,
+        configuredConfirmations: chainConfig.confirmations,
+      });
+      return;
+    }
+
     try {
-      logger.info("Cancelling sender after receiver cancelled", requestContext, methodContext);
+      logger.info("Cancelling sender after receiver cancelled", requestContext, methodContext, {
+        receiverCancelTransaction: {
+          transactionHash: receiverCancelledReceipt.transactionHash,
+          block: receiverCancelledReceipt.blockNumber,
+          confirmations: receiverCancelledReceipt.confirmations,
+        },
+      });
       receipt = await cancel(
         _transaction.crosschainTx.invariant,
         {

--- a/packages/router/src/bindings/contractReader/index.ts
+++ b/packages/router/src/bindings/contractReader/index.ts
@@ -62,13 +62,14 @@ export const bindContractReader = async () => {
           };
         });
 
-        logger.info("active transactions tracker", requestContext, methodContext, {
+        logger.info("Trackers overview", requestContext, methodContext, {
           activeTransactionsLength: transactions.length,
-          activeTransactionsTracker: activeTransactionsTracker,
+          handlingTrackerLength: handlingTracker.size,
         });
-        logger.info("handling tracker", requestContext, methodContext, {
+        logger.debug("Trackers detailed", requestContext, methodContext, {
           handlingTrackerLength: handlingTracker.size,
           handlingTracker: [...handlingTracker],
+          activeTransactionsTracker,
         });
       }
     } catch (err: any) {

--- a/packages/router/src/lib/helpers/metrics.ts
+++ b/packages/router/src/lib/helpers/metrics.ts
@@ -34,9 +34,10 @@ export const convertToUsd = async (
   assetId: string,
   chainId: number,
   amount: string,
-  requestContext: RequestContext,
+  _requestContext: RequestContext,
 ): Promise<number> => {
   const { txService, logger, chainData } = getContext();
+  const { requestContext, methodContext } = createLoggingContext(convertToUsd.name, _requestContext);
   const assetIdOnMainnet = await getMainnetEquivalent(chainId, assetId, chainData);
   const chainIdForTokenPrice = assetIdOnMainnet ? 1 : chainId;
   const assetIdForTokenPrice = assetIdOnMainnet ? assetIdOnMainnet : assetId;
@@ -50,7 +51,7 @@ export const convertToUsd = async (
   // Convert to USD
   const decimals = await getDecimals(assetId, chainId);
   const usdWei = BigNumber.from(amount).mul(price).div(BigNumber.from(10).pow(18));
-  logger.debug("Got value in wei", requestContext, undefined, {
+  logger.debug("Got value in wei", requestContext, methodContext, {
     assetId,
     chainId,
     decimals,

--- a/packages/router/test/bindings/contractReader/index.spec.ts
+++ b/packages/router/test/bindings/contractReader/index.spec.ts
@@ -318,6 +318,26 @@ describe("Contract Reader Binding", () => {
       });
     });
 
+    it("should wait for safe confirmations on ReceiverCancelled", async () => {
+      const senderExpiredNoReceiver: ActiveTransaction<"ReceiverCancelled"> = {
+        ...activeTransactionFulfillMock,
+        crosschainTx: {
+          ...activeTransactionFulfillMock.crosschainTx,
+          receiving: undefined,
+        },
+        payload: {
+          hashes: {
+            ...activeTransactionFulfillMock.payload.hashes,
+          },
+        },
+        status: CrosschainTransactionStatus.ReceiverCancelled,
+      };
+      txServiceMock.getTransactionReceipt.resolves({ ...txReceiptMock, confirmations: 1 });
+      await binding.handleSingle(senderExpiredNoReceiver, context);
+
+      expect(cancelMock.callCount).to.be.eq(0);
+    });
+
     it("should handle ReceiverCancelled with already canceled error", async () => {
       cancelMock.rejects(new Error("#C:019"));
       const senderExpiredNoReceiver: ActiveTransaction<"ReceiverCancelled"> = {


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- The `handling tracker` log being at info blows up logs when searching by `transactionId`
- Not waiting safe confirmations when handling `ReceiverCancelled`
- Add more logs about the receipt you are responding to when you have waited safe confirmations

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Move noisy logs to `debug`
- Wait safe confirmations for `ReceiverCancelled`
- Add logs to each action about the confirmed receipt for easier reorg debugging

## Checklist

- [x] Unit tests
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
