### PR TITLE
[txservice] Retry with direct provider read call if signer read call fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.1.20
 
+- [txservice] Retry with direct provider call if signer-based contract reads fail
 - [utils] Estimate gas updates
 
 ## 0.1.19


### PR DESCRIPTION
## The Problem

SDK is occasionally seeing issues doing contract reads... users have to refresh to make things work.
https://discord.com/channels/454734546869551114/527959697068654623/935898678969909328

## The Solution

I *think* it might have to do with the injected signer (given that this is occurring with SDK), so I went out on a limb here and just added an additional try/catch for signer-based contract reads, so that we resort to using provider contract reads directly if the signer-based call fails.

## Checklist

- [ ] Unit tests.
- [x] Update documentation if needed.
- [x] Update CHANGELOG.md.
