### PR TITLE
Add gasPricefactor

### DIFF
--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -444,7 +444,8 @@ export class ChainReader {
       gasLimit = BigNumber.from(isRouterContract ? gasLimits.removeLiquidityRouterContract : gasLimits.removeLiquidity);
     }
 
-    const gasAmountInUsd = gasPrice.mul(gasLimit).mul(ethPrice).add(l1GasInUsd);
+    const impactedGasPrice = gasPrice.mul(BigNumber.from(10).pow(18)).div(BigNumber.from(gasLimits.gasPriceFactor));
+    const gasAmountInUsd = impactedGasPrice.mul(gasLimit).mul(ethPrice).add(l1GasInUsd);
     const tokenAmountForGasFee = tokenPrice.isZero()
       ? constants.Zero
       : gasAmountInUsd.div(tokenPrice).div(BigNumber.from(10).pow(18 - decimals));
@@ -462,6 +463,7 @@ export class ChainReader {
       gas: {
         chainIdForGasPrice,
         price: gasPrice.toString(),
+        gasPriceFactor: gasLimits.gasPriceFactor,
         limit: gasLimit.toString(),
         ethPriceUsd: ethPrice.toString(),
         l1GasInUsd: l1GasInUsd.toString(),

--- a/packages/utils/src/chainData.ts
+++ b/packages/utils/src/chainData.ts
@@ -63,6 +63,7 @@ export type ChainData = {
     fulfillL1?: string;
     cancelL1?: string;
     removeLiquidityL1?: string;
+    gasPriceFactor?: string;
   };
 };
 

--- a/packages/utils/src/gasEstimates.ts
+++ b/packages/utils/src/gasEstimates.ts
@@ -13,6 +13,7 @@ export const DEFAULT_GAS_ESTIMATES = {
   fulfillRouterContract: "200000",
   cancelRouterContract: "204271",
   removeLiquidityRouterContract: "48000",
+  gasPriceFactor: "1000000000000000000",
 };
 
 export type GasEstimates = {
@@ -28,6 +29,7 @@ export type GasEstimates = {
   fulfillL1?: string;
   cancelL1?: string;
   removeLiquidityL1?: string;
+  gasPriceFactor: string;
 };
 
 export const getHardcodedGasLimits = async (
@@ -54,6 +56,7 @@ export const getHardcodedGasLimits = async (
   const fulfillL1 = chainInfo.gasEstimates?.fulfillL1 ?? DEFAULT_GAS_ESTIMATES.fulfillL1;
   const cancelL1 = chainInfo.gasEstimates?.cancelL1 ?? DEFAULT_GAS_ESTIMATES.cancelL1;
   const removeLiquidityL1 = chainInfo.gasEstimates?.removeLiquidityL1 ?? DEFAULT_GAS_ESTIMATES.removeLiquidityL1;
+  const gasPriceFactor = chainInfo.gasEstimates?.gasPriceFactor ?? DEFAULT_GAS_ESTIMATES.gasPriceFactor;
   const res = {
     prepare,
     fulfill,
@@ -67,6 +70,7 @@ export const getHardcodedGasLimits = async (
     fulfillL1,
     cancelL1,
     removeLiquidityL1,
+    gasPriceFactor,
   } as GasEstimates;
   return res;
 };


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The problem exists on layer 2 networks, especially on arbitrum one. We can just get gasPriceBid but gasPricePaid is actually used. 
 
## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
