### PR TITLE
[cache] Index transfers by transfer ID and collate

### DIFF
--- a/packages/adapters/cache/src/index.ts
+++ b/packages/adapters/cache/src/index.ts
@@ -1,10 +1,10 @@
 import { Logger } from "@connext/nxtp-utils";
 
-import { TransactionsCache, AuctionsCache, ConsumersCache } from "./lib/caches";
+import { TransfersCache, AuctionsCache, ConsumersCache } from "./lib/caches";
 import { StoreManagerParams, StoreChannel } from "./lib/entities";
 
 export interface Store {
-  readonly transactions: TransactionsCache;
+  readonly transfers: TransfersCache;
   readonly auctions: AuctionsCache;
   readonly consumers: ConsumersCache;
 }
@@ -19,17 +19,17 @@ export class StoreManager implements Store {
 
   private readonly logger: Logger;
 
-  public readonly transactions: TransactionsCache;
+  public readonly transfers: TransfersCache;
   public readonly auctions: AuctionsCache;
   public readonly consumers: ConsumersCache;
 
   private constructor({ redis, logger, mock }: StoreManagerParams) {
     this.logger = logger;
     const { url } = redis ?? {};
-    this.transactions = new TransactionsCache({
+    this.transfers = new TransfersCache({
       url,
       mock: !!mock,
-      logger: this.logger.child({ name: "TransactionsCache" }),
+      logger: this.logger.child({ name: "TransfersCache" }),
     });
     this.auctions = new AuctionsCache({
       url,

--- a/packages/adapters/cache/src/lib/caches/index.ts
+++ b/packages/adapters/cache/src/lib/caches/index.ts
@@ -1,6 +1,6 @@
 import { Cache } from "./cache";
-import { TransactionsCache } from "./transactions";
+import { TransfersCache } from "./transfers";
 import { AuctionsCache } from "./auctions";
 import { ConsumersCache } from "./consumers";
 
-export { Cache, TransactionsCache, AuctionsCache, ConsumersCache };
+export { Cache, TransfersCache, AuctionsCache, ConsumersCache };

--- a/packages/adapters/cache/src/lib/caches/transactions.ts
+++ b/packages/adapters/cache/src/lib/caches/transactions.ts
@@ -139,9 +139,9 @@ export class TransactionsCache extends Cache {
       if (xcall.transactionHash && !execute?.transactionHash && !reconcile?.transactionHash) {
         // If xcall but no execute or reconcile, then it's possibly a new transfer.
         newXCalls[transferId] = stringified;
-      } else if (execute?.transactionHash) {
-        // If execute, then it's a completed transfer. In case we've previously marked the xcall as new in
-        // this batch, we need to remove it from the newXCalls list.
+      } else if (execute?.transactionHash || reconcile?.transactionHash) {
+        // If execute (or reconcile), then it's a completed transfer. In case we've previously recorded
+        // the xcall as new in this batch, we need to remove it from the newXCalls list.
         delete newXCalls[transferId];
       }
       // Retrieve latest nonce for this domain.

--- a/packages/adapters/cache/src/lib/caches/transfers.ts
+++ b/packages/adapters/cache/src/lib/caches/transfers.ts
@@ -9,7 +9,7 @@ import { Cache } from ".";
  * Transaction Status by TransactionId
    key: $txid | value XTransferStatus as string
  */
-export class TransactionsCache extends Cache {
+export class TransfersCache extends Cache {
   private readonly prefix = "transactions";
   /**
    *

--- a/packages/adapters/cache/test/lib/caches/consumer.spec.ts
+++ b/packages/adapters/cache/test/lib/caches/consumer.spec.ts
@@ -8,14 +8,14 @@ import {
   XTransfer,
   delay,
 } from "@connext/nxtp-utils";
-import { ConsumersCache, TransactionsCache, AuctionsCache } from "../../../src/index";
+import { ConsumersCache, TransfersCache, AuctionsCache } from "../../../src/index";
 import { StoreChannel, SubscriptionCallback } from "../../../src/lib/entities";
 
 const logger = new Logger({ level: "debug" });
 const RedisMock = require("ioredis-mock");
 let consumers: ConsumersCache;
 let auctions: AuctionsCache;
-let transactions: TransactionsCache;
+let transactions: TransfersCache;
 
 const fakeTxs = [
   mock.entity.xtransfer("1000", "2000"),
@@ -72,7 +72,7 @@ describe("ConsumersCache", () => {
 
     consumers = new ConsumersCache({ url: "mock", mock: true, logger });
     auctions = new AuctionsCache({ url: "mock", mock: true, logger });
-    transactions = new TransactionsCache({ url: "mock", mock: true, logger });
+    transactions = new TransfersCache({ url: "mock", mock: true, logger });
   });
 
   describe("#subscribe", () => {
@@ -92,7 +92,7 @@ describe("ConsumersCache", () => {
     it("subscriptions should be called if the new message arrives from its channel", async () => {
       // StoreChannel.NewXCall
       expect(callCountForNewXCall).to.be.eq(0);
-      await transactions.storeTxData([fakeTxs[0]]);
+      await transactions.storeTransfers([fakeTxs[0]]);
       await delay(100);
       expect(callCountForNewXCall).to.be.eq(1);
 
@@ -110,7 +110,7 @@ describe("ConsumersCache", () => {
 
       // StoreChannel.NewHighestNonce
       callCountForHightedNonce = 0;
-      await transactions.storeTxData([fakeTxs[1]]);
+      await transactions.storeTransfers([fakeTxs[1]]);
       await delay(100);
       expect(callCountForHightedNonce).to.be.eq(1);
     });

--- a/packages/agents/router/src/bindings/subgraph/index.ts
+++ b/packages/agents/router/src/bindings/subgraph/index.ts
@@ -32,7 +32,7 @@ export const pollSubgraph = async () => {
       // TODO: Convert domain to chainID ??
       const latestBlockNumber = await txservice.getBlockNumber(parseInt(domain));
       const safeConfirmations = config.chains[domain].confirmations ?? DEFAULT_SAFE_CONFIRMATIONS;
-      const latestNonce = await cache.transactions.getLatestNonce(domain);
+      const latestNonce = await cache.transfers.getLatestNonce(domain);
       logger.debug("Retrieved domain information for subgraph polling", undefined, undefined, {
         domain,
         latestBlockNumber,
@@ -49,7 +49,7 @@ export const pollSubgraph = async () => {
     logger.debug("Got transactions", requestContext, methodContext, {
       transactions,
     });
-    await cache.transactions.storeTxData(transactions);
+    await cache.transfers.storeTransfers(transactions);
   } catch (err: any) {
     logger.error("Error getting pending txs, waiting for next loop", requestContext, methodContext, jsonifyError(err));
   }

--- a/packages/agents/router/src/router.ts
+++ b/packages/agents/router/src/router.ts
@@ -69,10 +69,12 @@ export const makeRouter = async () => {
       config: Object.assign(context.config, context.config.mnemonic ? { mnemonic: "......." } : { mnemonic: "N/A" }),
     });
 
-    // TODO: Sanity checks on boot:
+    // TODO: Cold start housekeeping.
+    // - send a ping request to sequencer
     // - read subgraph to make sure router is approved
-    // - read subgraph for current liquidity in each asset, cache it
+    // - read contract or subgraph for current liquidity in each asset, cache it
     // - read subgraph to make sure each asset is (still) approved
+    // - bring cache up to speed
 
     // Set up bindings.
     // TODO: New diagnostic mode / cleanup mode?

--- a/packages/agents/router/test/mock.ts
+++ b/packages/agents/router/test/mock.ts
@@ -1,6 +1,6 @@
 import { utils, BigNumber, Wallet } from "ethers";
 import { createStubInstance, SinonStub, SinonStubbedInstance, stub } from "sinon";
-import { AuctionsCache, TransactionsCache } from "@connext/nxtp-adapters-cache";
+import { AuctionsCache, TransfersCache } from "@connext/nxtp-adapters-cache";
 import { SubgraphReader } from "@connext/nxtp-adapters-subgraph";
 import { ConnextContractDeployments, ConnextContractInterfaces, TransactionService } from "@connext/nxtp-txservice";
 import { mkAddress, Logger, mock as _mock } from "@connext/nxtp-utils";
@@ -88,7 +88,7 @@ export const mock = {
       return wallet;
     },
     cache: (): any => {
-      const transactions = createStubInstance(TransactionsCache);
+      const transactions = createStubInstance(TransfersCache);
       const auctions = createStubInstance(AuctionsCache);
       transactions.getLatestNonce.resolves(0);
       return {

--- a/packages/agents/sequencer/test/mock.ts
+++ b/packages/agents/sequencer/test/mock.ts
@@ -1,6 +1,6 @@
 import { utils, BigNumber } from "ethers";
 import { createStubInstance, SinonStubbedInstance } from "sinon";
-import { AuctionsCache, StoreManager, TransactionsCache } from "@connext/nxtp-adapters-cache";
+import { AuctionsCache, StoreManager, TransfersCache } from "@connext/nxtp-adapters-cache";
 import { SubgraphReader } from "@connext/nxtp-adapters-subgraph";
 import { ChainReader, ConnextContractInterfaces } from "@connext/nxtp-txservice";
 import { mkAddress, Logger, mock as _mock, ExecuteArgs } from "@connext/nxtp-utils";
@@ -69,7 +69,7 @@ export const mock = {
   adapter: {
     cache: (): SinonStubbedInstance<StoreManager> => {
       const cache = createStubInstance(StoreManager);
-      const transactions = createStubInstance(TransactionsCache);
+      const transactions = createStubInstance(TransfersCache);
       const auctions = createStubInstance(AuctionsCache);
       // NOTE: if this override doesn't work, we should resort to just making a mock object with
       // these caches as properties.


### PR DESCRIPTION
## The Problem

In current model, we basically publish the `NewXCall` event  whenever there's a new `xcall` in general. This will result in the router immediately getting hundreds/thousands/etc `NewXCall` events fired off every time it boots and it's behind the current state on-chain. As a result, the router would be spamming the seq. with bids.

While we'll probably have some cold-start logic in the future (e.g. put a nonce to start with in the config for each chain, etc), I think it would be best to just go ahead and collate the data at some point in the process here in order to derive which `NewXCall` events are "valid".

## The Solution

TL;DR: "Don't publish NewXCall if it's not a New XCall"

I propose we do the collation in the cache itself. The update for this is pretty straightforward. We would move from indexing transfer data by domain+transferId -> indexing it *just* by `transferId` alone.

The upsert process (which results effectively in collation) would then look like this:
- look up `transferId` in current cache
- sanity check: confirm that the core transfer data / metadata stuff is the same (otherwise, just assume it's invalid... this shouldn't be possible/happen, but just for sanity)
- combine the data for the new given transfer with the existing cached transfer (if there is an existing cached transfer). This will result in combining the origin chain Transfer subgraph entity (with `xcall` property filled out) with the destination chain subgraph entity (with `execute` and `reconcile`, if those txs were completed)

NOTE: This won't achieve *perfect* knowledge of whether a `NewXCall` is truly a new xcall, since it's possible for the destination subgraph (or endpoint) to lag or fail for a bit, for instance. But it's much better than blindly forward every XCall the second we see it's an XCall.

This will also allow us to condense our storage/caching significantly! Otherwise, we'd be storing a lot of the same metadata for on two domains.
