### PR TITLE
[metrics] Fix router_gas_balance metric

### DIFF
--- a/packages/router/src/lib/helpers/metrics.ts
+++ b/packages/router/src/lib/helpers/metrics.ts
@@ -244,7 +244,7 @@ export const collectOnchainLiquidity = async (): Promise<Record<number, { assetI
 };
 
 export const collectGasBalance = async (): Promise<Record<number, number>> => {
-  const { config, txService, wallet, logger } = getContext();
+  const { config, txService, routerAddress, logger } = getContext();
 
   const balances: Record<number, number> = {};
   await Promise.all(
@@ -252,7 +252,7 @@ export const collectGasBalance = async (): Promise<Record<number, number>> => {
       .map((c) => +c)
       .map(async (chainId) => {
         try {
-          const balance = await txService.getBalance(chainId, await wallet.getAddress(), constants.AddressZero);
+          const balance = await txService.getBalance(chainId, routerAddress, constants.AddressZero);
           balances[chainId] = +utils.formatEther(balance.toString());
         } catch (e: any) {
           logger.warn("Failed to get gas balance", undefined, undefined, {


### PR DESCRIPTION
## The Problem

The gas fees during swaps are deducted from the router contracts. However, the `router_gas_balance` metric is currently collecting the balance from the signer address and not the router contract address.

## The Solution

Use the `routerAddress` from context instead, it will fall back to the signer address if not defined in the configuration file.

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
