### PR TITLE
Enforce providers present

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -435,9 +435,6 @@ export const getEnvConfig = (crossChainData: Map<string, any> | undefined): Nxtp
 
   // validate there are the right providers in place (always need mainnet for pricing)
   const providersRequired = new Set(nxtpConfig.swapPools.flatMap((s) => s.assets).map((a) => a.chainId));
-  if (!Object.keys(nxtpConfig.chainConfig).includes("1337") && !Object.keys(nxtpConfig.chainConfig).includes("1338")) {
-    providersRequired.add(1);
-  }
 
   const missing = [...providersRequired].filter((chain) => !Object.keys(nxtpConfig.chainConfig).includes(`${chain}`));
   if (missing.length > 0) {

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -434,7 +434,10 @@ export const getEnvConfig = (crossChainData: Map<string, any> | undefined): Nxtp
   }
 
   // validate there are the right providers in place (always need mainnet for pricing)
-  const providersRequired = new Set([1, ...nxtpConfig.swapPools.flatMap((s) => s.assets).map((a) => a.chainId)]);
+  const providersRequired = new Set(nxtpConfig.swapPools.flatMap((s) => s.assets).map((a) => a.chainId));
+  if (!Object.keys(nxtpConfig.chainConfig).includes("1337") && !Object.keys(nxtpConfig.chainConfig).includes("1338")) {
+    providersRequired.add(1);
+  }
 
   const missing = [...providersRequired].filter((chain) => !Object.keys(nxtpConfig.chainConfig).includes(`${chain}`));
   if (missing.length > 0) {

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -433,6 +433,14 @@ export const getEnvConfig = (crossChainData: Map<string, any> | undefined): Nxtp
     throw new Error(validate.errors?.map((err: any) => err.message).join(","));
   }
 
+  // validate there are the right providers in place (always need mainnet for pricing)
+  const providersRequired = new Set([1, ...nxtpConfig.swapPools.flatMap((s) => s.assets).map((a) => a.chainId)]);
+
+  const missing = [...providersRequired].filter((chain) => !Object.keys(nxtpConfig.chainConfig).includes(`${chain}`));
+  if (missing.length > 0) {
+    throw new Error(`Missing "chainConfig" entries for: ${missing}`);
+  }
+
   return nxtpConfig;
 };
 

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -11,6 +11,53 @@ import {
 import * as ConfigFns from "../src/config";
 import { configMock, chainDataMock } from "./utils";
 
+export const routerConfigMock = {
+  ...configMock,
+  chainConfig: {
+    1: {
+      confirmations: 10,
+      providers: ["http://example.com"],
+      subgraph: ["http://example.com"],
+      transactionManagerAddress: mkAddress("0xaaa"),
+      priceOracleAddress: mkAddress("0x0"),
+      multicallAddress: mkAddress("0x1"),
+      minGas: "100",
+      relayerFeeThreshold: 10,
+      subgraphSyncBuffer: 10,
+      gasStations: [],
+      allowRelay: true,
+      analyticsSubgraph: ["http://example.com"],
+    },
+    1337: {
+      confirmations: 1,
+      providers: ["http://example.com"],
+      subgraph: ["http://example.com"],
+      transactionManagerAddress: mkAddress("0xaaa"),
+      priceOracleAddress: mkAddress("0x0"),
+      multicallAddress: mkAddress("0x1"),
+      minGas: "100",
+      relayerFeeThreshold: 10,
+      subgraphSyncBuffer: 10,
+      gasStations: [],
+      allowRelay: true,
+      analyticsSubgraph: ["http://example.com"],
+    },
+    1338: {
+      confirmations: 1,
+      providers: ["http://example.com"],
+      subgraph: ["http://example.com"],
+      transactionManagerAddress: mkAddress("0xbbb"),
+      priceOracleAddress: mkAddress("0x0"),
+      multicallAddress: mkAddress("0x1"),
+      minGas: "100",
+      relayerFeeThreshold: 10,
+      subgraphSyncBuffer: 10,
+      gasStations: [],
+      allowRelay: true,
+      analyticsSubgraph: ["http://example.com"],
+    },
+  },
+};
 describe("Config", () => {
   let testChainId = 1336;
   let testAddress = "0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
@@ -113,7 +160,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_CONFIG_FILE: "buggypath",
         NXTP_NETWORK: "testnet",
-        NXTP_CONFIG: JSON.stringify(configMock),
+        NXTP_CONFIG: JSON.stringify(routerConfigMock),
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -124,7 +171,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...configMock,
+          ...routerConfigMock,
           chainConfig: {
             1337: {},
             1338: {},
@@ -140,7 +187,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...configMock,
+          ...routerConfigMock,
           chainConfig: {
             1337: { transactionManagerAddress: mkAddress("0xaaa"), subgraph: "http://example.com" },
             1338: { transactionManagerAddress: mkAddress("0xbbb"), subgraph: "http://example.com" },
@@ -155,7 +202,7 @@ describe("Config", () => {
       stub(process, "env").value({
         ...process.env,
         NXTP_NETWORK: "local",
-        NXTP_CONFIG: JSON.stringify(configMock),
+        NXTP_CONFIG: JSON.stringify(routerConfigMock),
       });
 
       let res;
@@ -173,7 +220,7 @@ describe("Config", () => {
     it("should read config from default filepath", () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_CONFIG: JSON.stringify(configMock),
+        NXTP_CONFIG: JSON.stringify(routerConfigMock),
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -182,13 +229,13 @@ describe("Config", () => {
     it("should getEnvConfig", () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: configMock.authUrl,
-        NXTP_NATS_URL: configMock.natsUrl,
-        NXTP_MNEMONIC: configMock.mnemonic,
-        NXTP_ADMIN_TOKEN: configMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
-        NXTP_LOG_LEVEL: configMock.logLevel,
+        NXTP_AUTH_URL: routerConfigMock.authUrl,
+        NXTP_NATS_URL: routerConfigMock.natsUrl,
+        NXTP_MNEMONIC: routerConfigMock.mnemonic,
+        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
+        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -199,9 +246,36 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...configMock,
+          ...routerConfigMock,
           chainConfig: {
-            1337: {},
+            1: {
+              confirmations: 10,
+              providers: ["http://example.com"],
+              subgraph: ["http://example.com"],
+              transactionManagerAddress: mkAddress("0xaaa"),
+              priceOracleAddress: mkAddress("0x0"),
+              multicallAddress: mkAddress("0x1"),
+              minGas: "100",
+              relayerFeeThreshold: 10,
+              subgraphSyncBuffer: 10,
+              gasStations: [],
+              allowRelay: true,
+              analyticsSubgraph: ["http://example.com"],
+            },
+            1337: {
+              confirmations: 1,
+              providers: ["http://example.com"],
+              subgraph: ["http://example.com"],
+              transactionManagerAddress: mkAddress("0xaaa"),
+              priceOracleAddress: mkAddress("0x0"),
+              multicallAddress: mkAddress("0x1"),
+              minGas: "100",
+              relayerFeeThreshold: 10,
+              subgraphSyncBuffer: 10,
+              gasStations: [],
+              allowRelay: true,
+              analyticsSubgraph: ["http://example.com"],
+            },
           },
         }),
       });
@@ -214,13 +288,13 @@ describe("Config", () => {
     it("should work", async () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: configMock.authUrl,
-        NXTP_NATS_URL: configMock.natsUrl,
-        NXTP_MNEMONIC: configMock.mnemonic,
-        NXTP_ADMIN_TOKEN: configMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
-        NXTP_LOG_LEVEL: configMock.logLevel,
+        NXTP_AUTH_URL: routerConfigMock.authUrl,
+        NXTP_NATS_URL: routerConfigMock.natsUrl,
+        NXTP_MNEMONIC: routerConfigMock.mnemonic,
+        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
+        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
       });
 
       const env = getEnvConfig(chainDataMock);
@@ -231,13 +305,13 @@ describe("Config", () => {
     it("should work without param", async () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: configMock.authUrl,
-        NXTP_NATS_URL: configMock.natsUrl,
-        NXTP_MNEMONIC: configMock.mnemonic,
-        NXTP_ADMIN_TOKEN: configMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
-        NXTP_LOG_LEVEL: configMock.logLevel,
+        NXTP_AUTH_URL: routerConfigMock.authUrl,
+        NXTP_NATS_URL: routerConfigMock.natsUrl,
+        NXTP_MNEMONIC: routerConfigMock.mnemonic,
+        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
+        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
       });
 
       const env = getEnvConfig(chainDataMock);

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -11,53 +11,6 @@ import {
 import * as ConfigFns from "../src/config";
 import { configMock, chainDataMock } from "./utils";
 
-export const routerConfigMock = {
-  ...configMock,
-  chainConfig: {
-    1: {
-      confirmations: 10,
-      providers: ["http://example.com"],
-      subgraph: ["http://example.com"],
-      transactionManagerAddress: mkAddress("0xaaa"),
-      priceOracleAddress: mkAddress("0x0"),
-      multicallAddress: mkAddress("0x1"),
-      minGas: "100",
-      relayerFeeThreshold: 10,
-      subgraphSyncBuffer: 10,
-      gasStations: [],
-      allowRelay: true,
-      analyticsSubgraph: ["http://example.com"],
-    },
-    1337: {
-      confirmations: 1,
-      providers: ["http://example.com"],
-      subgraph: ["http://example.com"],
-      transactionManagerAddress: mkAddress("0xaaa"),
-      priceOracleAddress: mkAddress("0x0"),
-      multicallAddress: mkAddress("0x1"),
-      minGas: "100",
-      relayerFeeThreshold: 10,
-      subgraphSyncBuffer: 10,
-      gasStations: [],
-      allowRelay: true,
-      analyticsSubgraph: ["http://example.com"],
-    },
-    1338: {
-      confirmations: 1,
-      providers: ["http://example.com"],
-      subgraph: ["http://example.com"],
-      transactionManagerAddress: mkAddress("0xbbb"),
-      priceOracleAddress: mkAddress("0x0"),
-      multicallAddress: mkAddress("0x1"),
-      minGas: "100",
-      relayerFeeThreshold: 10,
-      subgraphSyncBuffer: 10,
-      gasStations: [],
-      allowRelay: true,
-      analyticsSubgraph: ["http://example.com"],
-    },
-  },
-};
 describe("Config", () => {
   let testChainId = 1336;
   let testAddress = "0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
@@ -160,7 +113,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_CONFIG_FILE: "buggypath",
         NXTP_NETWORK: "testnet",
-        NXTP_CONFIG: JSON.stringify(routerConfigMock),
+        NXTP_CONFIG: JSON.stringify(configMock),
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -171,7 +124,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...routerConfigMock,
+          ...configMock,
           chainConfig: {
             1337: {},
             1338: {},
@@ -187,7 +140,7 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...routerConfigMock,
+          ...configMock,
           chainConfig: {
             1337: { transactionManagerAddress: mkAddress("0xaaa"), subgraph: "http://example.com" },
             1338: { transactionManagerAddress: mkAddress("0xbbb"), subgraph: "http://example.com" },
@@ -202,7 +155,7 @@ describe("Config", () => {
       stub(process, "env").value({
         ...process.env,
         NXTP_NETWORK: "local",
-        NXTP_CONFIG: JSON.stringify(routerConfigMock),
+        NXTP_CONFIG: JSON.stringify(configMock),
       });
 
       let res;
@@ -220,7 +173,7 @@ describe("Config", () => {
     it("should read config from default filepath", () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_CONFIG: JSON.stringify(routerConfigMock),
+        NXTP_CONFIG: JSON.stringify(configMock),
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -229,13 +182,13 @@ describe("Config", () => {
     it("should getEnvConfig", () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: routerConfigMock.authUrl,
-        NXTP_NATS_URL: routerConfigMock.natsUrl,
-        NXTP_MNEMONIC: routerConfigMock.mnemonic,
-        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
-        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
+        NXTP_AUTH_URL: configMock.authUrl,
+        NXTP_NATS_URL: configMock.natsUrl,
+        NXTP_MNEMONIC: configMock.mnemonic,
+        NXTP_ADMIN_TOKEN: configMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
+        NXTP_LOG_LEVEL: configMock.logLevel,
       });
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
@@ -246,22 +199,8 @@ describe("Config", () => {
         ...process.env,
         NXTP_NETWORK: "local",
         NXTP_CONFIG: JSON.stringify({
-          ...routerConfigMock,
+          ...configMock,
           chainConfig: {
-            1: {
-              confirmations: 10,
-              providers: ["http://example.com"],
-              subgraph: ["http://example.com"],
-              transactionManagerAddress: mkAddress("0xaaa"),
-              priceOracleAddress: mkAddress("0x0"),
-              multicallAddress: mkAddress("0x1"),
-              minGas: "100",
-              relayerFeeThreshold: 10,
-              subgraphSyncBuffer: 10,
-              gasStations: [],
-              allowRelay: true,
-              analyticsSubgraph: ["http://example.com"],
-            },
             1337: {
               confirmations: 1,
               providers: ["http://example.com"],
@@ -288,13 +227,13 @@ describe("Config", () => {
     it("should work", async () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: routerConfigMock.authUrl,
-        NXTP_NATS_URL: routerConfigMock.natsUrl,
-        NXTP_MNEMONIC: routerConfigMock.mnemonic,
-        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
-        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
+        NXTP_AUTH_URL: configMock.authUrl,
+        NXTP_NATS_URL: configMock.natsUrl,
+        NXTP_MNEMONIC: configMock.mnemonic,
+        NXTP_ADMIN_TOKEN: configMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
+        NXTP_LOG_LEVEL: configMock.logLevel,
       });
 
       const env = getEnvConfig(chainDataMock);
@@ -305,13 +244,13 @@ describe("Config", () => {
     it("should work without param", async () => {
       stub(process, "env").value({
         ...process.env,
-        NXTP_AUTH_URL: routerConfigMock.authUrl,
-        NXTP_NATS_URL: routerConfigMock.natsUrl,
-        NXTP_MNEMONIC: routerConfigMock.mnemonic,
-        NXTP_ADMIN_TOKEN: routerConfigMock.adminToken,
-        NXTP_CHAIN_CONFIG: JSON.stringify(routerConfigMock.chainConfig),
-        NXTP_SWAP_POOLS: JSON.stringify(routerConfigMock.swapPools),
-        NXTP_LOG_LEVEL: routerConfigMock.logLevel,
+        NXTP_AUTH_URL: configMock.authUrl,
+        NXTP_NATS_URL: configMock.natsUrl,
+        NXTP_MNEMONIC: configMock.mnemonic,
+        NXTP_ADMIN_TOKEN: configMock.adminToken,
+        NXTP_CHAIN_CONFIG: JSON.stringify(configMock.chainConfig),
+        NXTP_SWAP_POOLS: JSON.stringify(configMock.swapPools),
+        NXTP_LOG_LEVEL: configMock.logLevel,
       });
 
       const env = getEnvConfig(chainDataMock);

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -193,6 +193,21 @@ describe("Config", () => {
 
       expect(() => getEnvConfig(chainDataMock)).not.throw();
     });
+
+    it("should fail if there are missing chainConfigs", () => {
+      stub(process, "env").value({
+        ...process.env,
+        NXTP_NETWORK: "local",
+        NXTP_CONFIG: JSON.stringify({
+          ...configMock,
+          chainConfig: {
+            1337: {},
+          },
+        }),
+      });
+
+      expect(() => getEnvConfig(chainDataMock)).throw(`Missing "chainConfig" entries for: ${[1338]}`);
+    });
   });
 
   describe("getConfig", () => {

--- a/packages/router/test/lib/helpers/metrics.spec.ts
+++ b/packages/router/test/lib/helpers/metrics.spec.ts
@@ -164,7 +164,9 @@ describe("collectExpressiveLiquidity", () => {
     (contractReaderMock.getExpressiveAssetBalances as SinonStub).onCall(0).rejects(new Error("Fail"));
     (contractReaderMock.getExpressiveAssetBalances as SinonStub).onCall(1).resolves([]);
     const ret = await metrics.collectExpressiveLiquidity();
-    expect(ret).to.be.deep.eq({ [Object.keys(configMock.chainConfig)[1]]: [] });
+    expect(ret).to.be.deep.eq({
+      [Object.keys(configMock.chainConfig)[1]]: [],
+    });
     expect((contractReaderMock.getExpressiveAssetBalances as SinonStub).callCount).to.be.eq(
       Object.keys(configMock.chainConfig).length,
     );

--- a/packages/router/test/lib/helpers/shared.spec.ts
+++ b/packages/router/test/lib/helpers/shared.spec.ts
@@ -78,7 +78,7 @@ describe("getContractAddress", () => {
     expect(shared.getContractAddress(1338)).to.be.eq(mkAddress("0xbbb"));
   });
   it("should throw error", () => {
-    expect(() => shared.getContractAddress(1)).to.throw(Error);
+    expect(() => shared.getContractAddress(56)).to.throw(Error);
   });
 });
 


### PR DESCRIPTION
## The Problem

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Routers can start up without providers for each of their configured swaps

## The Solution

<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

- Add validation on config

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
