### PR TITLE
Add InitiateClaim and Claim functionalities to Connext

### DIFF
--- a/packages/deployments/contracts/contracts/Connext.sol
+++ b/packages/deployments/contracts/contracts/Connext.sol
@@ -624,11 +624,11 @@ contract Connext is
    */
   // TODO - move to lib
   function initiateClaim(
-    address _recipient,
     uint32 _domain,
+    address _recipient,
     bytes32[] calldata _transferIds
   ) public {
-    ConnextUtils.initiateClaim(_recipient, _domain, _transferIds, relayerFeeRouter, transferRelayer);
+    ConnextUtils.initiateClaim(_domain, _recipient, _transferIds, relayerFeeRouter, transferRelayer);
     // TODO - emit event?
   }
 

--- a/packages/deployments/contracts/contracts/Connext.sol
+++ b/packages/deployments/contracts/contracts/Connext.sol
@@ -622,25 +622,27 @@ contract Connext is
    * @param _domain - domain to claim funds on
    * @param _transferIds - transferIds to claim
    */
-  // TODO - move to lib
   function initiateClaim(
     uint32 _domain,
     address _recipient,
     bytes32[] calldata _transferIds
   ) public {
     ConnextUtils.initiateClaim(_domain, _recipient, _transferIds, relayerFeeRouter, transferRelayer);
-    // TODO - emit event?
+
+    emit InitiatedClaim(_domain, _recipient, msg.sender, _transferIds);
   }
 
   /**
    * @notice Pays out a relayer for the given fees
    * @dev Called by the RelayerFeeRouter.handle message. The validity of the transferIds is
    * asserted before dispatching the message.
+   * @param _recipient - address on origin chain to send claimed funds to
+   * @param _transferIds - transferIds to claim
    */
-  // TODO - move to lib
   function claim(address _recipient, bytes32[] calldata _transferIds) public onlyRelayerFeeRouter {
-    ConnextUtils.claim(_recipient, _transferIds, relayerFees);
-    // TODO - emit event?
+    uint256 total = ConnextUtils.claim(_recipient, _transferIds, relayerFees);
+
+    emit Claimed(_recipient, total, _transferIds);
   }
 
   // ============ Private functions ============

--- a/packages/deployments/contracts/contracts/Connext.sol
+++ b/packages/deployments/contracts/contracts/Connext.sol
@@ -626,7 +626,7 @@ contract Connext is
     uint32 _domain,
     address _recipient,
     bytes32[] calldata _transferIds
-  ) public {
+  ) external {
     ConnextUtils.initiateClaim(_domain, _recipient, _transferIds, relayerFeeRouter, transferRelayer);
 
     emit InitiatedClaim(_domain, _recipient, msg.sender, _transferIds);
@@ -639,7 +639,7 @@ contract Connext is
    * @param _recipient - address on origin chain to send claimed funds to
    * @param _transferIds - transferIds to claim
    */
-  function claim(address _recipient, bytes32[] calldata _transferIds) public onlyRelayerFeeRouter {
+  function claim(address _recipient, bytes32[] calldata _transferIds) external onlyRelayerFeeRouter {
     uint256 total = ConnextUtils.claim(_recipient, _transferIds, relayerFees);
 
     emit Claimed(_recipient, total, _transferIds);

--- a/packages/deployments/contracts/contracts/interfaces/IConnext.sol
+++ b/packages/deployments/contracts/contracts/interfaces/IConnext.sol
@@ -232,6 +232,23 @@ interface IConnext {
     address caller
   );
 
+  /**
+   * @notice Emitted when `initiateClaim` is called on the destination chain
+   * @param recipient - Address on origin chain to send claimed funds to
+   * @param domain - Domain to claim funds on
+   * @param transferIds - TransferIds to claim
+   * @param caller - The account that called the function
+   */
+  event InitiatedClaim(uint32 indexed domain, address indexed recipient, address caller, bytes32[] transferIds);
+
+  /**
+   * @notice Emitted when `claim` is called on the origin domain
+   * @param recipient - Address on origin chain to send claimed funds to
+   * @param total - Total amount claimed
+   * @param transferIds - TransferIds to claim
+   */
+  event Claimed(address indexed recipient, uint256 total, bytes32[] transferIds);
+
   // ============ Admin Functions ============
 
   function initialize(

--- a/packages/deployments/contracts/contracts/interfaces/IConnext.sol
+++ b/packages/deployments/contracts/contracts/interfaces/IConnext.sol
@@ -238,7 +238,8 @@ interface IConnext {
     uint256 _domain,
     address payable _bridgeRouter,
     address _tokenRegistry, // Nomad token registry
-    address _wrappedNative
+    address _wrappedNative,
+    address _relayerFeeRouter
   ) external;
 
   function setupRouter(

--- a/packages/deployments/contracts/contracts/interfaces/IConnext.sol
+++ b/packages/deployments/contracts/contracts/interfaces/IConnext.sol
@@ -234,10 +234,10 @@ interface IConnext {
 
   /**
    * @notice Emitted when `initiateClaim` is called on the destination chain
-   * @param recipient - Address on origin chain to send claimed funds to
    * @param domain - Domain to claim funds on
-   * @param transferIds - TransferIds to claim
+   * @param recipient - Address on origin chain to send claimed funds to
    * @param caller - The account that called the function
+   * @param transferIds - TransferIds to claim
    */
   event InitiatedClaim(uint32 indexed domain, address indexed recipient, address caller, bytes32[] transferIds);
 

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
@@ -172,7 +172,6 @@ library ConnextUtils {
    * @param _recipient - address on origin chain to send claimed funds to
    * @param _transferIds - transferIds to claim
    */
-  // TODO - Is this the proper place?
   function initiateClaim(
     uint32 _domain,
     address _recipient,
@@ -198,18 +197,14 @@ library ConnextUtils {
    * @dev Called by the RelayerFeeRouter.handle message. The validity of the transferIds is
    * asserted before dispatching the message.
    */
-  // TODO - Is this the proper place?
   function claim(
     address _recipient,
     bytes32[] calldata _transferIds,
     mapping(bytes32 => uint256) storage relayerFees
-  ) public {
+  ) public returns (uint256) {
     // Tally amounts owed
     uint256 total;
     for (uint256 i; i < _transferIds.length; ) {
-      // TODO: maybe assert gas here to ensure you have enough to include
-      // transferId and buffer to send? That way you can at least claim *some*
-      // of the transfers
       total += relayerFees[_transferIds[i]];
       relayerFees[_transferIds[i]] = 0;
       unchecked {
@@ -218,5 +213,7 @@ library ConnextUtils {
     }
 
     AddressUpgradeable.sendValue(payable(_recipient), total);
+
+    return total;
   }
 }

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
@@ -7,12 +7,18 @@ import "../../interfaces/IStableSwap.sol";
 import "../../nomad-xapps/contracts/bridge/TokenRegistry.sol";
 import "../../nomad-xapps/contracts/bridge/BridgeMessage.sol";
 import "../../nomad-xapps/contracts/bridge/BridgeRouter.sol";
+import "../../nomad-xapps/contracts/relayer-fee-router/RelayerFeeRouter.sol";
 import {TypeCasts} from "../../nomad-core/contracts/XAppConnectionManager.sol";
 
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 library ConnextUtils {
+  // ========== Custom Errors ===========
+  error ConnextUtils__initiateClaim_notRelayer(bytes32 transferId);
+
+  // ========== Logic ===========
+
   /**
    * @notice Gets unique identifier from nonce + domain
    * @param _nonce - The nonce of the contract
@@ -157,5 +163,60 @@ library ConnextUtils {
 
     // Otherwise, swap to adopted asset
     return (pool.swapExact(_amount, _asset, adopted), adopted);
+  }
+
+  /**
+   * @notice Called by relayer when they want to claim owed funds on a given domain
+   * @dev Domain should be the origin domain of all the transfer ids
+   * @param _recipient - address on origin chain to send claimed funds to
+   * @param _domain - domain to claim funds on
+   * @param _transferIds - transferIds to claim
+   */
+  // TODO - Is this the proper place?
+  function initiateClaim(
+    address _recipient,
+    uint32 _domain,
+    bytes32[] calldata _transferIds,
+    RelayerFeeRouter relayerFeeRouter,
+    mapping(bytes32 => address) storage transferRelayer
+  ) public {
+    // Ensure the relayer can claim all transfers specified
+    for (uint256 i; i < _transferIds.length; ) {
+      if (transferRelayer[_transferIds[i]] != msg.sender)
+        revert ConnextUtils__initiateClaim_notRelayer(_transferIds[i]);
+      unchecked {
+        i++;
+      }
+    }
+
+    // Send transferIds via nomad
+    relayerFeeRouter.send(_domain, _recipient, _transferIds);
+  }
+
+  /**
+   * @notice Pays out a relayer for the given fees
+   * @dev Called by the RelayerFeeRouter.handle message. The validity of the transferIds is
+   * asserted before dispatching the message.
+   */
+  // TODO - Is this the proper place?
+  function claim(
+    address _recipient,
+    bytes32[] calldata _transferIds,
+    mapping(bytes32 => uint256) storage relayerFees
+  ) public {
+    // Tally amounts owed
+    uint256 total;
+    for (uint256 i; i < _transferIds.length; ) {
+      // TODO: maybe assert gas here to ensure you have enough to include
+      // transferId and buffer to send? That way you can at least claim *some*
+      // of the transfers
+      total += relayerFees[_transferIds[i]];
+      relayerFees[_transferIds[i]] = 0;
+      unchecked {
+        i++;
+      }
+    }
+
+    AddressUpgradeable.sendValue(payable(_recipient), total);
   }
 }

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextUtils.sol
@@ -168,14 +168,14 @@ library ConnextUtils {
   /**
    * @notice Called by relayer when they want to claim owed funds on a given domain
    * @dev Domain should be the origin domain of all the transfer ids
-   * @param _recipient - address on origin chain to send claimed funds to
    * @param _domain - domain to claim funds on
+   * @param _recipient - address on origin chain to send claimed funds to
    * @param _transferIds - transferIds to claim
    */
   // TODO - Is this the proper place?
   function initiateClaim(
-    address _recipient,
     uint32 _domain,
+    address _recipient,
     bytes32[] calldata _transferIds,
     RelayerFeeRouter relayerFeeRouter,
     mapping(bytes32 => address) storage transferRelayer

--- a/packages/deployments/contracts/contracts/nomad-xapps/contracts/relayer-fee-router/RelayerFeeRouter.sol
+++ b/packages/deployments/contracts/contracts/nomad-xapps/contracts/relayer-fee-router/RelayerFeeRouter.sol
@@ -71,11 +71,6 @@ contract RelayerFeeRouter is Version0, Router {
    */
   event SetConnext(address indexed connext);
 
-  // ======== Receive =======
-  receive() external payable {}
-
-  fallback() external payable {}
-
   // ============ Modifiers ============
 
   /**

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -29,6 +29,8 @@ contract ConnextTest is ForgeHelper {
   using stdStorage for StdStorage;
 
   event MaxRoutersPerTransferUpdated(uint256 maxRouters, address caller);
+  event InitiatedClaim(uint32 indexed domain, address indexed recipient, address caller, bytes32[] transferIds);
+  event Claimed(address indexed recipient, uint256 total, bytes32[] transferIds);
 
   // ============ Storage ============
 
@@ -150,12 +152,15 @@ contract ConnextTest is ForgeHelper {
       abi.encodeWithSelector(MockRelayerFeeRouter.send.selector, uint32(domain), kakaroto, transactionIds)
     );
 
+    vm.expectEmit(true, true, true, true);
+    emit InitiatedClaim(uint32(domain), kakaroto, kakaroto, transactionIds);
+
     connext.initiateClaim(uint32(domain), kakaroto, transactionIds);
   }
 
   // ============ claim ============
 
-  // Fail if if the caller isn't RelayerFeeRouter
+  // Fail if the caller isn't RelayerFeeRouter
   function testClaimOnlyRelayerFeeRouter() public {
     bytes32[] memory transactionIds = new bytes32[](2);
     transactionIds[0] = "AAA";
@@ -184,6 +189,9 @@ contract ConnextTest is ForgeHelper {
     vm.prank(address(relayerFeeRouter));
 
     uint256 balanceBefore = kakaroto.balance;
+
+    vm.expectEmit(true, true, true, true);
+    emit Claimed(kakaroto, aaaFee + bbbFee, transactionIds);
 
     connext.claim(kakaroto, transactionIds);
 

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -196,5 +196,7 @@ contract ConnextTest is ForgeHelper {
     connext.claim(kakaroto, transactionIds);
 
     assertEq(kakaroto.balance, balanceBefore + aaaFee + bbbFee);
+    assertEq(connext.relayerFees(bytes32("AAA")), 0);
+    assertEq(connext.relayerFees(bytes32("BBB")), 0);
   }
 }

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -28,12 +28,13 @@ contract ConnextTest is ForgeHelper {
   address bridgeRouter = address(1);
   address tokenRegistry = address(2);
   address wrapper = address(3);
+  address relayerFeeRouter = address(4);
 
   // ============ Test set up ============
 
   function setUp() public {
     connext = new Connext();
-    connext.initialize(domain, payable(bridgeRouter), tokenRegistry, wrapper);
+    connext.initialize(domain, payable(bridgeRouter), tokenRegistry, wrapper, relayerFeeRouter);
   }
 
   // ============ Utils ============

--- a/packages/deployments/contracts/contracts_forge/RouterPermissionsManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/RouterPermissionsManager.t.sol
@@ -20,12 +20,13 @@ contract RouterPermissionsManagerTest is ForgeHelper {
   address bridgeRouter = address(1);
   address tokenRegistry = address(2);
   address wrapper = address(3);
+  address relayerFeeRouter = address(4);
 
   // ============ Test set up ============
 
   function setUp() public {
     connext = new Connext();
-    connext.initialize(domain, payable(bridgeRouter), tokenRegistry, wrapper);
+    connext.initialize(domain, payable(bridgeRouter), tokenRegistry, wrapper, relayerFeeRouter);
   }
 
   // ============ Utils ============

--- a/packages/deployments/contracts/deploy/02_deployConnext.ts
+++ b/packages/deployments/contracts/deploy/02_deployConnext.ts
@@ -70,7 +70,8 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment): Promise<voi
       execute: {
         init: {
           methodName: "initialize",
-          args: [nomadConfig.domain, bridge.address, tokenRegistry.address, nomadConfig.wrappedEth],
+          // TODO - Use real RelayerFeeRouter
+          args: [nomadConfig.domain, bridge.address, tokenRegistry.address, nomadConfig.wrappedEth, hre.ethers.constants.AddressZero],
         },
       },
       proxyContract: "OpenZeppelinTransparentProxy",

--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -167,18 +167,22 @@ describe("Connext", () => {
       ConnextUtils: connextUtils.address,
       RouterPermissionsManagerLogic: routerPermissionsManagerLogic.address,
     });
-    await originTm.initialize(originDomain, originBridge.address, originTokenRegistry.address, weth.address);
+    // TODO - Use real RelayerFeeRouter
+    await originTm.initialize(originDomain, originBridge.address, originTokenRegistry.address, weth.address, ZERO_ADDRESS);
 
     destinationTm = await deployContractWithLibs<Connext>("Connext", {
       AssetLogic: assetLogic.address,
       ConnextUtils: connextUtils.address,
       RouterPermissionsManagerLogic: routerPermissionsManagerLogic.address,
     });
+
+    // TODO - Use real RelayerFeeRouter
     await destinationTm.initialize(
       destinationDomain,
       destinationBridge.address,
       destinationTokenRegistry.address,
       weth.address,
+      ZERO_ADDRESS
     );
     // Deploy home
     home = await deployContract<Home>("Home", originDomain);


### PR DESCRIPTION
## The Problem

Subtask of #900 
The relayers need a way to initiate the claim for it fees in the destination domain which should be fulfilled in the origin domain by the RelayerFeeRouter

## The Solution

Add `initiateClaim` and `claim` functionalities to Connext

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
