### PR TITLE
Add bumpTransfer method

### DIFF
--- a/packages/deployments/contracts/contracts/Connext.sol
+++ b/packages/deployments/contracts/contracts/Connext.sol
@@ -63,6 +63,7 @@ contract Connext is
   error Connext__decrementLiquidity_maxRoutersExceeded();
   error Connext__handleRelayerFees_notRtrSig();
   error Connext__setMaxRoutersPerTransfer_invalidMaxRoutersPerTransfer();
+  error Connext__bumpTransfer_invalidTransfer();
   error Connext__bumpTransfer_valueIsZero();
 
   // ============ Constants =============
@@ -475,11 +476,10 @@ contract Connext is
 
   /**
    * @notice Anyone can call this function on the origin domain to increase the relayer fee for a transfer.
-   * @dev Is not possible to validate the transfer id, so it is up to the caller to ensure that the transfer id
-   * is correct.
    * @param _transferId - The unique identifier of the crosschain transaction
    */
   function bumpTransfer(bytes32 _transferId) external payable {
+    if (relayerFees[_transferId] == 0) revert Connext__bumpTransfer_invalidTransfer();
     if (msg.value == 0) revert Connext__bumpTransfer_valueIsZero();
 
     relayerFees[_transferId] += msg.value;

--- a/packages/deployments/contracts/contracts/Connext.sol
+++ b/packages/deployments/contracts/contracts/Connext.sol
@@ -63,6 +63,7 @@ contract Connext is
   error Connext__decrementLiquidity_maxRoutersExceeded();
   error Connext__handleRelayerFees_notRtrSig();
   error Connext__setMaxRoutersPerTransfer_invalidMaxRoutersPerTransfer();
+  error Connext__bumpTransfer_valueIsZero();
 
   // ============ Constants =============
 
@@ -470,6 +471,20 @@ contract Connext is
 
     // Return the transfer id
     return _transferId;
+  }
+
+  /**
+   * @notice Anyone can call this function on the origin domain to increase the relayer fee for a transfer.
+   * @dev Is not possible to validate the transfer id, so it is up to the caller to ensure that the transfer id
+   * is correct.
+   * @param _transferId - The unique identifier of the crosschain transaction
+   */
+  function bumpTransfer(bytes32 _transferId) external payable {
+    if (msg.value == 0) revert Connext__bumpTransfer_valueIsZero();
+
+    relayerFees[_transferId] += msg.value;
+
+    emit TransferRelayerFeesUpdated(_transferId, relayerFees[_transferId], msg.sender);
   }
 
   /**

--- a/packages/deployments/contracts/contracts/interfaces/IConnext.sol
+++ b/packages/deployments/contracts/contracts/interfaces/IConnext.sol
@@ -190,6 +190,14 @@ interface IConnext {
   );
 
   /**
+   * @notice Emitted when `bumpTransfer` is called by an user on the origin domain
+   * @param transferId - The unique identifier of the crosschain transaction
+   * @param relayerFee - The updated amount of relayer fee in native asset
+   * @param caller - The account that called the function
+   */
+  event TransferRelayerFeesUpdated(bytes32 indexed transferId, uint256 relayerFee, address caller);
+
+  /**
    * @notice Emitted when `reconciled` is called by the bridge on the destination domain
    * @param transferId - The unique identifier of the crosschain transaction
    * @param origin - The origin domain of the transfer


### PR DESCRIPTION
## The Problem

Subtask of https://github.com/connext/nxtp/issues/900 , built on top of https://github.com/connext/nxtp/pull/955
The ability for user to send along an additional fee to “bump” the transaction

## The Solution
Add a bumpTransfer method to be called on the origin domain


## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
