### PR TITLE
save auction bids indexed by router addr

### DIFF
--- a/packages/adapters/cache/src/lib/caches/auctions.ts
+++ b/packages/adapters/cache/src/lib/caches/auctions.ts
@@ -61,7 +61,10 @@ export class AuctionsCache extends Cache {
       timestamp: existing?.timestamp ?? getNtpTimeSeconds().toString(),
       origin,
       destination,
-      bids: [...(existing?.bids ?? []), bid],
+      bids: {
+        ...(existing?.bids ?? {}),
+        [bid.router]: bid,
+      },
     };
     const res = await this.data.hset(`${this.prefix}:auction`, transferId, JSON.stringify(auction));
 

--- a/packages/adapters/cache/test/lib/caches/auctions.spec.ts
+++ b/packages/adapters/cache/test/lib/caches/auctions.spec.ts
@@ -107,7 +107,9 @@ describe("AuctionCache", () => {
         expect(auction).to.deep.eq({
           origin: args.origin,
           destination: args.destination,
-          bids: [args.bid],
+          bids: {
+            [args.bid.router]: args.bid,
+          },
         });
       });
 
@@ -133,7 +135,9 @@ describe("AuctionCache", () => {
           ...args,
           origin,
           destination,
-          bids: [firstBid],
+          bids: {
+            [firstBid.router]: firstBid,
+          },
         });
 
         const secondCallRes = await cache.upsertAuction({
@@ -148,7 +152,10 @@ describe("AuctionCache", () => {
           timestamp: firstCallTimestamp,
           origin,
           destination,
-          bids: [firstBid, secondBid],
+          bids: {
+            [firstBid.router]: firstBid,
+            [secondBid.router]: secondBid,
+          },
         });
       });
     });

--- a/packages/agents/router/src/bindings/subgraph/index.ts
+++ b/packages/agents/router/src/bindings/subgraph/index.ts
@@ -39,7 +39,7 @@ export const pollSubgraph = async () => {
     for (const domain of Object.keys(config.chains)) {
       // TODO: Needs to implement the selection algorithm
       const healthUrls = config.chains[domain].subgraph.runtime.map((url) => {
-        return { name: getSubgraphName(url.query ), url: url.health };
+        return { name: getSubgraphName(url.query), url: url.health };
       });
       let latestBlockNumber = 0;
       for (const healthEp of healthUrls) {

--- a/packages/agents/sequencer/src/lib/operations/auctions.ts
+++ b/packages/agents/sequencer/src/lib/operations/auctions.ts
@@ -146,7 +146,7 @@ export const executeAuctions = async (_requestContext: RequestContext) => {
 
         // TODO: Reimplement auction rounds!
         // hardcoded round 1
-        const availableBids = bids.filter((bid) => {
+        const availableBids = Object.values(bids).filter((bid) => {
           // TODO: Check to make sure the router has enough funds to execute this bid!
           return Array.from(Object.keys(bid.signatures)).includes("1");
         });

--- a/packages/utils/src/mocks/mock.ts
+++ b/packages/utils/src/mocks/mock.ts
@@ -95,7 +95,9 @@ export const mock: any = {
       timestamp: getNtpTimeSeconds().toString(),
       origin: mock.domain.A,
       destination: mock.domain.B,
-      bids: [mock.entity.bid()],
+      bids: {
+        [mock.address.router]: mock.entity.bid(),
+      },
       ...overrides,
     }),
     bid: (overrides: Partial<Bid> = {}): Bid => ({

--- a/packages/utils/src/types/api.ts
+++ b/packages/utils/src/types/api.ts
@@ -49,7 +49,7 @@ export const AuctionsApiBidResponseSchema = Type.Object({
 export type AuctionsApiBidResponse = Static<typeof AuctionsApiBidResponseSchema>;
 
 export const AuctionsApiGetAuctionsStatusResponseSchema = Type.Object({
-  bids: Type.Array(BidSchema),
+  bids: Type.Record(Type.String(), BidSchema),
   status: Type.String(),
   attempts: Type.Optional(Type.Number()),
   taskId: Type.Optional(Type.String()),

--- a/packages/utils/src/types/auctions.ts
+++ b/packages/utils/src/types/auctions.ts
@@ -40,7 +40,9 @@ export type AuctionHeader = Static<typeof AuctionHeaderSchema>;
 
 // Auction type - used for caching.
 export type Auction = AuctionHeader & {
-  bids: Bid[];
+  bids: {
+    [router: string]: Bid;
+  };
 };
 
 // Record of important data for an auction's meta tx.


### PR DESCRIPTION
Router bids are just building up into an endless list on backend bc they're not indexed by router address... it's just adding redundant bids.

Fix to index by router addr. If a router sends in a bid, it replaces the previous one it had set.
