### PR TITLE
Sponsoring fee execute logic

### DIFF
--- a/packages/deployments/contracts/contracts/interfaces/IConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/interfaces/IConnextHandler.sol
@@ -55,6 +55,7 @@ interface IConnextHandler {
     address[] routers;
     bytes[] routerSignatures;
     uint256 amount;
+    uint256 relayerFee;
     uint256 nonce;
     address originSender;
   }
@@ -92,6 +93,8 @@ interface IConnextHandler {
   function addRelayer(address relayer) external;
 
   function removeRelayer(address relayer) external;
+
+  function setSponsorVault(address sponsorVault) external;
 
   // ============ Public Functions ===========
 

--- a/packages/deployments/contracts/contracts/interfaces/ISponsorVault.sol
+++ b/packages/deployments/contracts/contracts/interfaces/ISponsorVault.sol
@@ -5,12 +5,12 @@ interface ISponsorVault {
   // Should be callable by the Connext contract only. Should:
   // - call `addLiquidityFor` to send the calculated fee to the router
   // - return the amount of liquidity router was reimbursed
-  function reimburseLiquidityFees(uint256 fee, address asset, address router) external returns (uint256);
+  function reimburseLiquidityFees(address adopted, uint256 amount) external returns (uint256);
 
   // Should be callable by the Connext contract only. Should:
   // - take in an amount of relayer fee specified on origin chain
   // - convert that amount to destination domain gas
   // - send the user the destination domain gas
   // -
-  function reimburseRelayerFees(uint256 relayerFee) external;
+  function reimburseRelayerFees(uint32 originDomain, address to, uint256 relayerFee) external;
 }

--- a/packages/deployments/contracts/contracts/interfaces/ISponsorVault.sol
+++ b/packages/deployments/contracts/contracts/interfaces/ISponsorVault.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.11;
+
+interface ISponsorVault {
+  // Should be callable by the Connext contract only. Should:
+  // - call `addLiquidityFor` to send the calculated fee to the router
+  // - return the amount of liquidity router was reimbursed
+  function reimburseLiquidityFees(uint256 fee, address asset, address router) external returns (uint256);
+
+  // Should be callable by the Connext contract only. Should:
+  // - take in an amount of relayer fee specified on origin chain
+  // - convert that amount to destination domain gas
+  // - send the user the destination domain gas
+  // -
+  function reimburseRelayerFees(uint256 relayerFee) external;
+}

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
@@ -5,6 +5,7 @@ import {IConnextHandler} from "../../interfaces/IConnextHandler.sol";
 import {IStableSwap} from "../../interfaces/IStableSwap.sol";
 import {IWrapped} from "../../interfaces/IWrapped.sol";
 import {IExecutor} from "../../interfaces/IExecutor.sol";
+import {ISponsorVault} from "../../interfaces/ISponsorVault.sol";
 import {LibCrossDomainProperty} from "../LibCrossDomainProperty.sol";
 import {RouterPermissionsManagerInfo} from "./RouterPermissionsManagerLogic.sol";
 import {AssetLogic} from "./AssetLogic.sol";
@@ -17,7 +18,7 @@ import {TypeCasts} from "../../nomad-core/contracts/XAppConnectionManager.sol";
 import {Home} from "../../nomad-core/contracts/Home.sol";
 
 import {ECDSAUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
-import {SafeERC20Upgradeable, AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import {SafeERC20Upgradeable, IERC20Upgradeable, AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 library ConnextLogic {
   // ============ Libraries ============
@@ -52,6 +53,7 @@ library ConnextLogic {
   error ConnextLogic__initiateClaim_notRelayer(bytes32 transferId);
   error ConnextLogic__bumpTransfer_invalidTransfer();
   error ConnextLogic__bumpTransfer_valueIsZero();
+  error ConnextLogic__handleExecuteTransaction_invalidSponsoredAmount();
 
   // ============ Structs ============
 
@@ -79,6 +81,7 @@ library ConnextLogic {
     ITokenRegistry tokenRegistry;
     IWrapped wrapper;
     IExecutor executor;
+    ISponsorVault sponsorVault;
     uint256 liquidityFeeNumerator;
     uint256 liquidityFeeDenominator;
   }
@@ -895,6 +898,33 @@ library ConnextLogic {
     bytes32 _transferId,
     bool _reconciled
   ) private {
+
+    // Is the domain sponsor
+    if (address(_args.sponsorVault) != address(0)) {
+      // fast liquidity path
+      if (!_reconciled) {
+        // Vault will return the amount of the fee they sponsored in the native fee
+        // NOTE: some considerations here around fee on transfer tokens and ensuring
+        // there are no malicious `Vaults` that do not transfer the correct amount. Should likely do a
+        // balance read about it
+
+        uint256 starting = IERC20Upgradeable(_adopted).balanceOf(address(this));
+        uint256 sponsored = _args.sponsorVault.reimburseLiquidityFees(_adopted, _args.executeArgs.amount);
+
+        // Validate correct amounts are transferred
+        if (IERC20Upgradeable(_adopted).balanceOf(address(this)) != starting + sponsored) {
+          revert ConnextLogic__handleExecuteTransaction_invalidSponsoredAmount();
+        }
+
+        _amount = _amount + sponsored;
+      }
+
+      // Should dust the recipient with the lesser of a vault-defined cap or the converted relayer fee
+      // If there is no conversion available (i.e. no oracles for origin domain asset <> dest asset pair),
+      // then the vault should just pay out the configured constant
+      _args.sponsorVault.reimburseRelayerFees(_args.executeArgs.params.originDomain, _args.executeArgs.params.to, _args.executeArgs.relayerFee);
+    }
+
     // execute the the transaction
     if (keccak256(_args.executeArgs.params.callData) == EMPTY) {
       // no call data, send funds to the user
@@ -943,8 +973,6 @@ library ConnextLogic {
         _args.liquidityFeeNumerator,
         _args.liquidityFeeDenominator
       );
-
-      // TODO: validate routers signature on path / transferId
 
       // store the routers address
       _routedTransfers[_transferId] = _args.executeArgs.routers;

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
@@ -34,6 +34,7 @@ library ConnextLogic {
   error ConnextLogic__addRelayer_alreadyApproved();
   error ConnextLogic__removeRelayer_notApproved();
   error ConnextLogic__setMaxRoutersPerTransfer_invalidMaxRoutersPerTransfer();
+  error ConnextLogic__setSponsorVault_invalidSponsorVault();
   error ConnextLogic__reconcile_invalidAction();
   error ConnextLogic__reconcile_alreadyReconciled();
   error ConnextLogic__removeLiquidity_recipientEmpty();
@@ -150,6 +151,13 @@ library ConnextLogic {
    * @param caller - The account that called the function
    */
   event MaxRoutersPerTransferUpdated(uint256 maxRoutersPerTransfer, address caller);
+
+  /**
+   * @notice Emitted when the sponsorVault variable is updated
+   * @param sponsorVault - The sponsorVault new value
+   * @param caller - The account that called the function
+   */
+  event SponsorVaultUpdated(address sponsorVault, address caller);
 
   /**
    * @notice Emitted when `xcall` is called on the origin domain
@@ -337,6 +345,18 @@ library ConnextLogic {
       revert ConnextLogic__setMaxRoutersPerTransfer_invalidMaxRoutersPerTransfer();
 
     emit MaxRoutersPerTransferUpdated(_newMax, msg.sender);
+  }
+
+  /**
+   * @notice Used to set the sponsor vault
+   * @param _sponsorVault The new sponsor vault
+   * @param _currentSponsorVault The current sponsor vault
+   */
+  function setSponsorVault(address _sponsorVault, address _currentSponsorVault) external {
+    if (_sponsorVault == _currentSponsorVault)
+      revert ConnextLogic__setSponsorVault_invalidSponsorVault();
+
+    emit SponsorVaultUpdated(_sponsorVault, msg.sender);
   }
 
   // ============ Functions ============

--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
@@ -157,10 +157,11 @@ library ConnextLogic {
 
   /**
    * @notice Emitted when the sponsorVault variable is updated
-   * @param sponsorVault - The sponsorVault new value
+   * @param oldSponsorVault - The sponsorVault old value
+   * @param newSponsorVault - The sponsorVault new value
    * @param caller - The account that called the function
    */
-  event SponsorVaultUpdated(address sponsorVault, address caller);
+  event SponsorVaultUpdated(address oldSponsorVault, address newSponsorVault, address caller);
 
   /**
    * @notice Emitted when `xcall` is called on the origin domain
@@ -359,7 +360,7 @@ library ConnextLogic {
     if (_sponsorVault == _currentSponsorVault)
       revert ConnextLogic__setSponsorVault_invalidSponsorVault();
 
-    emit SponsorVaultUpdated(_sponsorVault, msg.sender);
+    emit SponsorVaultUpdated(_currentSponsorVault, _sponsorVault, msg.sender);
   }
 
   // ============ Functions ============

--- a/packages/deployments/contracts/contracts/nomad-xapps/contracts/connext/ConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/nomad-xapps/contracts/connext/ConnextHandler.sol
@@ -17,6 +17,7 @@ import {IWrapped} from "../../../interfaces/IWrapped.sol";
 import {IConnextHandler} from "../../../interfaces/IConnextHandler.sol";
 import {IExecutor} from "../../../interfaces/IExecutor.sol";
 import {IStableSwap} from "../../../interfaces/IStableSwap.sol";
+import {ISponsorVault} from "../../../interfaces/ISponsorVault.sol";
 
 import {Executor} from "../../../interpreters/Executor.sol";
 import {RouterPermissionsManager} from "../../../RouterPermissionsManager.sol";
@@ -166,6 +167,11 @@ contract ConnextHandler is
    * @notice The max amount of routers a payment can be routed through
    */
   uint256 public maxRoutersPerTransfer;
+
+  /**
+   * @notice The Vault used for sponsoring fees
+   */
+  ISponsorVault public sponsorVault;
 
   // ============ Errors ============
 
@@ -318,6 +324,11 @@ contract ConnextHandler is
     ConnextLogic.setMaxRoutersPerTransfer(_newMaxRouters, maxRoutersPerTransfer);
 
     maxRoutersPerTransfer = _newMaxRouters;
+  }
+
+  function setSponsorVault(address _sponsorVault) external override onlyOwner {
+    ConnextLogic.setSponsorVault(_sponsorVault, address(sponsorVault));
+    sponsorVault = ISponsorVault(_sponsorVault);
   }
 
   // ============ External functions ============

--- a/packages/deployments/contracts/contracts/nomad-xapps/contracts/connext/ConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/nomad-xapps/contracts/connext/ConnextHandler.sol
@@ -454,6 +454,7 @@ contract ConnextHandler is
       tokenRegistry: tokenRegistry,
       wrapper: wrapper,
       executor: executor,
+      sponsorVault: sponsorVault,
       liquidityFeeNumerator: LIQUIDITY_FEE_NUMERATOR,
       liquidityFeeDenominator: LIQUIDITY_FEE_DENOMINATOR
     });

--- a/packages/deployments/contracts/contracts/test/TestSponsorVault.sol
+++ b/packages/deployments/contracts/contracts/test/TestSponsorVault.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.11;
+
+
+import "../interfaces/ISponsorVault.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+contract TestSponsorVault is ISponsorVault {
+
+  uint256 liquidityFeeToSend;
+  uint256 liquidityFeeToReturn;
+  uint256 relayerFeeToSend;
+
+  receive() external payable {}
+
+  function setFeeValues(
+    uint256 _liquidityFeeToSend,
+    uint256 _liquidityFeeToReturn,
+    uint256 _relayerFeeToSend
+  ) external {
+    liquidityFeeToSend = _liquidityFeeToSend;
+    liquidityFeeToReturn = _liquidityFeeToReturn;
+    relayerFeeToSend = _relayerFeeToSend;
+  }
+
+  function reimburseLiquidityFees(address adopted, uint256 amount) external override returns (uint256) {
+    IERC20Upgradeable(adopted).transfer(msg.sender, liquidityFeeToSend);
+    return liquidityFeeToReturn;
+  }
+
+  function reimburseRelayerFees(uint32 originDomain, address to, uint256 relayerFee) external override {
+    to.call{value: relayerFeeToSend}("");
+  }
+
+}

--- a/packages/deployments/contracts/contracts_forge/ConnextHandler.t.sol
+++ b/packages/deployments/contracts/contracts_forge/ConnextHandler.t.sol
@@ -48,7 +48,7 @@ contract ConnextHandlerTest is ForgeHelper {
     address caller
   );
   event TransferRelayerFeesUpdated(bytes32 indexed transferId, uint256 relayerFee, address caller);
-  event SponsorVaultUpdated(address sponsorVault, address caller);
+  event SponsorVaultUpdated(address oldSponsorVault, address newSponsorVault, address caller);
 
   // ============ Storage ============
 
@@ -206,7 +206,7 @@ contract ConnextHandlerTest is ForgeHelper {
     vm.assume(_newSponsorVault != address(0));
 
     vm.expectEmit(true, true, true, true);
-    emit SponsorVaultUpdated(_newSponsorVault, address(this));
+    emit SponsorVaultUpdated(address(0), _newSponsorVault, address(this));
 
     connext.setSponsorVault(_newSponsorVault);
     assertEq(address(connext.sponsorVault()), _newSponsorVault);
@@ -219,7 +219,7 @@ contract ConnextHandlerTest is ForgeHelper {
     assertEq(address(connext.sponsorVault()), _currentSponsorVault);
 
     vm.expectEmit(true, true, true, true);
-    emit SponsorVaultUpdated(address(0), address(this));
+    emit SponsorVaultUpdated(_currentSponsorVault, address(0), address(this));
 
     connext.setSponsorVault(address(0));
     assertEq(address(connext.sponsorVault()), address(0));

--- a/packages/deployments/contracts/contracts_forge/ConnextHandler.t.sol
+++ b/packages/deployments/contracts/contracts_forge/ConnextHandler.t.sol
@@ -48,6 +48,7 @@ contract ConnextHandlerTest is ForgeHelper {
     address caller
   );
   event TransferRelayerFeesUpdated(bytes32 indexed transferId, uint256 relayerFee, address caller);
+  event SponsorVaultUpdated(address sponsorVault, address caller);
 
   // ============ Storage ============
 
@@ -158,6 +159,17 @@ contract ConnextHandlerTest is ForgeHelper {
     vm.store(address(connext), bytes32(slot), bytes32(uint256(uint160(_relayer))));
   }
 
+  function setSponsorVault(address _sponsorVault) internal {
+    // stdstore does not work correctly with proxies to set a value directly with checked_write()
+    // use impl to find the storage slot
+    uint256 slot = stdstore
+      .target(address(connextImpl))
+      .sig(connextImpl.sponsorVault.selector)
+      .find();
+    // update the proxy storage
+    vm.store(address(connext), bytes32(slot), bytes32(uint256(uint160(_sponsorVault))));
+  }
+
   // ============ setMaxRouters ============
 
   // Should work
@@ -186,6 +198,50 @@ contract ConnextHandlerTest is ForgeHelper {
       abi.encodeWithSelector(ConnextLogic.ConnextLogic__setMaxRoutersPerTransfer_invalidMaxRoutersPerTransfer.selector)
     );
     connext.setMaxRoutersPerTransfer(0);
+  }
+
+  // ============ setSponsorVault ============
+
+  function test_ConnextHandler__setSponsorVault_worksAddingNewSponsorVault(address _newSponsorVault) public {
+    vm.assume(_newSponsorVault != address(0));
+
+    vm.expectEmit(true, true, true, true);
+    emit SponsorVaultUpdated(_newSponsorVault, address(this));
+
+    connext.setSponsorVault(_newSponsorVault);
+    assertEq(address(connext.sponsorVault()), _newSponsorVault);
+  }
+
+  function test_ConnextHandler__setSponsorVault_worksRemovingSponsorVault(address _currentSponsorVault) public {
+    vm.assume(_currentSponsorVault != address(0));
+
+    setSponsorVault(_currentSponsorVault);
+    assertEq(address(connext.sponsorVault()), _currentSponsorVault);
+
+    vm.expectEmit(true, true, true, true);
+    emit SponsorVaultUpdated(address(0), address(this));
+
+    connext.setSponsorVault(address(0));
+    assertEq(address(connext.sponsorVault()), address(0));
+  }
+
+  function test_ConnextHandler__setSponsorVault_failsIfNotOwner() public {
+    vm.prank(address(0));
+    vm.expectRevert(
+      abi.encodeWithSelector(ProposedOwnableUpgradeable.ProposedOwnableUpgradeable__onlyOwner_notOwner.selector)
+    );
+    connext.setSponsorVault(address(1));
+  }
+
+  function test_ConnextHandler__setSponsorVault_failsIfAddingSameSponsorVault(address _currentSponsorVault) public {
+    setSponsorVault(_currentSponsorVault);
+    assertEq(address(connext.sponsorVault()), _currentSponsorVault);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(ConnextLogic.ConnextLogic__setSponsorVault_invalidSponsorVault.selector)
+    );
+
+    connext.setSponsorVault(_currentSponsorVault);
   }
 
   // ============ initiateClaim ============

--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -15,6 +15,7 @@ import {
   ConnextHandler,
   ConnextLogic,
   RelayerFeeRouter,
+  TestSponsorVault
 } from "../typechain-types";
 
 import {
@@ -885,6 +886,7 @@ describe("Connext", () => {
       nonce,
       local: local.address,
       amount,
+      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -982,6 +984,7 @@ describe("Connext", () => {
       nonce,
       local: destinationAdopted.address,
       amount,
+      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -1067,6 +1070,7 @@ describe("Connext", () => {
       nonce,
       local: local.address,
       amount,
+      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -1088,6 +1092,7 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
+        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1107,6 +1112,7 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
+        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1127,6 +1133,7 @@ describe("Connext", () => {
     let transferId: any;
     let bridgedAmount: any;
     let reconciledTopics: any;
+    let relayerFee: any;
 
     beforeEach(async () => {
       await originBridge.setupRouter(router2.address, router2.address, router2.address);
@@ -1158,7 +1165,7 @@ describe("Connext", () => {
 
       // Prepare from the user
       const transactingAssetId = originAdopted.address;
-      const relayerFee = utils.parseEther("0.00000001");
+      relayerFee = utils.parseEther("0.00000001");
       const prepare = await originBridge
         .connect(user)
         .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
@@ -1204,6 +1211,7 @@ describe("Connext", () => {
           nonce,
           local: local.address,
           amount,
+          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1281,6 +1289,7 @@ describe("Connext", () => {
           nonce,
           local: local.address,
           amount,
+          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1296,6 +1305,7 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
+        relayerFee,
         routers: routerAddresses,
         routerSignatures,
         originSender: user.address,
@@ -1324,6 +1334,7 @@ describe("Connext", () => {
           nonce,
           local: local.address,
           amount: routersAmount,
+          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1402,6 +1413,7 @@ describe("Connext", () => {
             nonce: transferIds[i].nonce,
             local: local.address,
             amount: amounts[i],
+            relayerFee: relayerFees[i],
             routers: [router.address],
             routerSignatures: [await signRouterPathPayload(transferIds[i].transferId, "1", router)],
             originSender: user.address,
@@ -1445,4 +1457,333 @@ describe("Connext", () => {
       });
     });
   });
+
+  describe("sponsoring fee", () => {
+    let sponsorVault: TestSponsorVault;
+    let params: any;
+    let amount: any;
+    let relayerFee: any;
+    let routerAmount: any;
+    let liquidityFee: any;
+    let transactingAssetId: any;
+    let nonce: any;
+    let message: any;
+    let transferId: any;
+
+    before(async () => {
+      sponsorVault = await deployContract<TestSponsorVault>("TestSponsorVault");
+
+      // Mint to sponsor vault
+      const mint = await destinationAdopted.mint(sponsorVault.address, parseEther("20"));
+      await mint.wait();
+
+      await (await admin.sendTransaction({to: sponsorVault.address, value: parseEther("1")})).wait()
+
+      // Setup stable swap for adopted => canonical on origin
+      const swapCanonical = await stableSwap
+      .connect(admin)
+      .setupPool(originAdopted.address, canonical.address, SEED, SEED);
+      await swapCanonical.wait();
+
+      // Setup stable swap for local => adopted on dest
+      const swapLocal = await stableSwap
+        .connect(admin)
+        .setupPool(destinationAdopted.address, local.address, SEED.mul(2), SEED.mul(2));
+      await swapLocal.wait();
+
+      // Add router liquidity
+      const approveLiq = await local.connect(router).approve(destinationBridge.address, parseEther("100000"));
+      await approveLiq.wait();
+      const addLiq = await destinationBridge.connect(router).addLiquidity(parseEther("0.1"), local.address);
+      await addLiq.wait();
+
+      // Approve user
+      const approveAmt = await originAdopted.connect(user).approve(originBridge.address, parseEther("100000"));
+      await approveAmt.wait();
+
+      amount = utils.parseEther("0.0001");
+      relayerFee = utils.parseEther("0.00000001");
+      routerAmount = amount.mul(9995).div(10000);
+      liquidityFee = amount.sub(routerAmount);
+
+      // Prepare from the user
+      params = {
+        to: user.address,
+        callData: "0x",
+        originDomain,
+        destinationDomain,
+      };
+      transactingAssetId = originAdopted.address;
+
+      const prepare = await originBridge
+        .connect(user)
+        .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+      const prepareReceipt = await prepare.wait();
+
+      const xcalledTopic = ConnextLogic.filters.XCalled().topics as string[];
+      const originBridgeEvent = ConnextLogic.interface.parseLog(
+        prepareReceipt.logs.find((l) => l.topics.includes(xcalledTopic[0]))!,
+      );
+
+      nonce = (originBridgeEvent!.args as any).nonce;
+      message = (originBridgeEvent!.args as any).message;
+      transferId = (originBridgeEvent!.args as any).transferId;
+    })
+
+    it("should work with no sponsor vault configured", async () => {
+      expect(await destinationBridge.sponsorVault()).to.eq(ZERO_ADDRESS);
+
+      // Get pre-prepare balances
+      const prePrepare = await Promise.all([
+        originAdopted.balanceOf(user.address),
+        canonical.balanceOf(originBridge.address),
+      ]);
+
+      // Get pre-execute balances
+      const preExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+      ]);
+
+      // Fulfill with the router
+      const execute = await destinationBridge.connect(router).execute({
+        params,
+        nonce,
+        local: local.address,
+        amount,
+        relayerFee,
+        routers: [router.address],
+        routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+        originSender: user.address,
+      });
+      const execReceipt = await execute.wait();
+
+      const executedTopic = ConnextLogic.filters.Executed().topics as string[];
+      const destTmEvent = ConnextLogic.interface.parseLog(
+        execReceipt.logs.find((l) => l.topics.includes(executedTopic[0]))!,
+      );
+      expect((destTmEvent!.args as any).transferId).to.be.eq(transferId);
+
+      expect(await destinationBridge.transferRelayer(transferId)).to.eq(router.address);
+
+      // Check balance of user + bridge
+      const postExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+      ]);
+      expect(postExecute[0]).to.be.eq(preExecute[0].add(routerAmount));
+      expect(postExecute[1]).to.be.eq(preExecute[1].sub(routerAmount));
+    });
+
+    it("should work with sponsor vault configured and working properly", async () => {
+      // configure sponsor vault
+      await destinationBridge.setSponsorVault(sponsorVault.address);
+      // test sponsor vault setup
+      await sponsorVault.setFeeValues(liquidityFee, liquidityFee, relayerFee);
+
+      // Get pre-execute balances
+      const preExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+
+      // Fulfill with the router
+      const execute = await destinationBridge.connect(router).execute({
+        params,
+        nonce,
+        local: local.address,
+        amount,
+        relayerFee,
+        routers: [router.address],
+        routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+        originSender: user.address,
+      });
+      const execReceipt = await execute.wait();
+
+      const executedTopic = ConnextLogic.filters.Executed().topics as string[];
+      const destTmEvent = ConnextLogic.interface.parseLog(
+        execReceipt.logs.find((l) => l.topics.includes(executedTopic[0]))!,
+      );
+      expect((destTmEvent!.args as any).transferId).to.be.eq(transferId);
+
+      expect(await destinationBridge.transferRelayer(transferId)).to.eq(router.address);
+
+      // Check balance of user + bridge
+      const postExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+      expect(postExecute[0]).to.be.eq(preExecute[0].add(routerAmount.add(liquidityFee))); // user receives the sponsored liquidity fee
+      expect(postExecute[1]).to.be.eq(preExecute[1].sub(routerAmount));
+      expect(postExecute[2]).to.be.eq(preExecute[2].add(relayerFee)); // user receives the sponsored relayer fee back on the destination domain
+    });
+
+    it("should work with sponsor vault configured and working properly sponsoring a portion of liquidity fee", async () => {
+      liquidityFee = liquidityFee.div(2);
+
+      // configure sponsor vault
+      await destinationBridge.setSponsorVault(sponsorVault.address);
+      // test sponsor vault setup
+      await sponsorVault.setFeeValues(liquidityFee, liquidityFee, relayerFee);
+
+      // Get pre-execute balances
+      const preExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+
+      // Fulfill with the router
+      const execute = await destinationBridge.connect(router).execute({
+        params,
+        nonce,
+        local: local.address,
+        amount,
+        relayerFee,
+        routers: [router.address],
+        routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+        originSender: user.address,
+      });
+      const execReceipt = await execute.wait();
+
+      const executedTopic = ConnextLogic.filters.Executed().topics as string[];
+      const destTmEvent = ConnextLogic.interface.parseLog(
+        execReceipt.logs.find((l) => l.topics.includes(executedTopic[0]))!,
+      );
+      expect((destTmEvent!.args as any).transferId).to.be.eq(transferId);
+
+      expect(await destinationBridge.transferRelayer(transferId)).to.eq(router.address);
+
+      // Check balance of user + bridge
+      const postExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+      expect(postExecute[0]).to.be.eq(preExecute[0].add(routerAmount.add(liquidityFee))); // user receives the sponsored liquidity fee
+      expect(postExecute[1]).to.be.eq(preExecute[1].sub(routerAmount));
+      expect(postExecute[2]).to.be.eq(preExecute[2].add(relayerFee)); // user receives the sponsored relayer fee back on the destination domain
+    });
+
+    it("should work with sponsor vault configured and working properly sponsoring a portion of relayer fee", async () => {
+      liquidityFee = liquidityFee.div(2);
+      const sponsoredRelayerFee = relayerFee.div(2);
+
+      // configure sponsor vault
+      await destinationBridge.setSponsorVault(sponsorVault.address);
+      // test sponsor vault setup
+      await sponsorVault.setFeeValues(liquidityFee, liquidityFee, sponsoredRelayerFee);
+
+      // Get pre-execute balances
+      const preExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+
+      // Fulfill with the router
+      const execute = await destinationBridge.connect(router).execute({
+        params,
+        nonce,
+        local: local.address,
+        amount,
+        relayerFee,
+        routers: [router.address],
+        routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+        originSender: user.address,
+      });
+      const execReceipt = await execute.wait();
+
+      const executedTopic = ConnextLogic.filters.Executed().topics as string[];
+      const destTmEvent = ConnextLogic.interface.parseLog(
+        execReceipt.logs.find((l) => l.topics.includes(executedTopic[0]))!,
+      );
+      expect((destTmEvent!.args as any).transferId).to.be.eq(transferId);
+
+      expect(await destinationBridge.transferRelayer(transferId)).to.eq(router.address);
+
+      // Check balance of user + bridge
+      const postExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+      expect(postExecute[0]).to.be.eq(preExecute[0].add(routerAmount.add(liquidityFee))); // user receives the sponsored liquidity fee
+      expect(postExecute[1]).to.be.eq(preExecute[1].sub(routerAmount));
+      expect(postExecute[2]).to.be.eq(preExecute[2].add(sponsoredRelayerFee)); // user receives the sponsored relayer fee back on the destination domain
+    });
+
+    it("should work with sponsor vault configured but not sponsoring", async () => {
+      // configure sponsor vault
+      await destinationBridge.setSponsorVault(sponsorVault.address);
+      // test sponsor vault setup
+      await sponsorVault.setFeeValues(0, 0, 0);
+
+      // Get pre-execute balances
+      const preExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+
+      // Fulfill with the router
+      const execute = await destinationBridge.connect(router).execute({
+        params,
+        nonce,
+        local: local.address,
+        amount,
+        relayerFee,
+        routers: [router.address],
+        routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+        originSender: user.address,
+      });
+      const execReceipt = await execute.wait();
+
+      const executedTopic = ConnextLogic.filters.Executed().topics as string[];
+      const destTmEvent = ConnextLogic.interface.parseLog(
+        execReceipt.logs.find((l) => l.topics.includes(executedTopic[0]))!,
+      );
+      expect((destTmEvent!.args as any).transferId).to.be.eq(transferId);
+
+      expect(await destinationBridge.transferRelayer(transferId)).to.eq(router.address);
+
+      // Check balance of user + bridge
+      const postExecute = await Promise.all([
+        destinationAdopted.balanceOf(user.address),
+        destinationBridge.routerBalances(router.address, local.address),
+        user.getBalance(),
+      ]);
+      expect(postExecute[0]).to.be.eq(preExecute[0].add(routerAmount)); // user does not receive the sponsored liquidity fee
+      expect(postExecute[1]).to.be.eq(preExecute[1].sub(routerAmount));
+      expect(postExecute[2]).to.be.eq(preExecute[2]); // user does not receive the sponsored relayer fee back on the destination domain
+    });
+
+    it("should fail with malicious sponsor vault configured", async () => {
+      const amount = utils.parseEther("0.0001");
+      const relayerFee = utils.parseEther("0.00000001");
+      const routerAmount = amount.mul(9995).div(10000);
+      const liquidityFee = amount.sub(routerAmount).div(2);
+      const sponsoredRelayerFee = relayerFee.div(2);
+
+      // configure sponsor vault
+      await destinationBridge.setSponsorVault(sponsorVault.address);
+      // test sponsor vault setup to send les liquidity fee than it says it will
+      await sponsorVault.setFeeValues(liquidityFee.div(2), liquidityFee, sponsoredRelayerFee);
+
+      await expect(
+        destinationBridge.connect(router).execute({
+          params,
+          nonce,
+          local: local.address,
+          amount,
+          relayerFee,
+          routers: [router.address],
+          routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
+          originSender: user.address,
+        })
+      ).to.revertedWith("ConnextLogic__handleExecuteTransaction_invalidSponsoredAmount()")
+    });
+  })
 });


### PR DESCRIPTION
## The Problem

subtask of #1060 
ConnextHandler execute logic needs to be integrated with ISponsorVault to be able to sponsor liquidity and relayer fees

## The Solution

Add new logic to handle sponsoring fees

## Checklist

- [ ] Test manually on `test-ui` using remote chains.
- [ ] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
