### PR TITLE
Fixed Gelato gas estimation on Optimism

### DIFF
--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -468,7 +468,7 @@ export class ChainReader {
         chainIdForGasPrice,
         assetId,
         gasLimit.toNumber(),
-        parseInt(gasEstimate),
+        +gasEstimate,
       );
       gelatoEstimatedFee = gelatoEstimatedFee
         ? decimals > inputDecimals

--- a/packages/txservice/src/chainreader.ts
+++ b/packages/txservice/src/chainreader.ts
@@ -411,9 +411,9 @@ export class ChainReader {
 
     // https://community.optimism.io/docs/users/fees-2.0.html#fees-in-a-nutshell
     let l1GasInUsd = BigNumber.from(0);
+    let gasEstimate = "0";
     if (chainIdForGasPrice === 10) {
       const gasPriceMainnet = await this.getGasPrice(1, requestContext);
-      let gasEstimate = "0";
       if (method === "prepare") {
         gasEstimate = gasLimits.prepareL1 ?? "0";
       } else if (method === "fulfill") {
@@ -464,7 +464,12 @@ export class ChainReader {
     let gelatoEstimatedFee: BigNumber | undefined;
     if (this.config[chainIdForTokenPrice] && this.config[chainIdForTokenPrice].gelatoOracle) {
       const inputDecimals = await this.getDecimalsForAsset(chainId, assetId);
-      gelatoEstimatedFee = await this.calculateGelatoFee(chainIdForGasPrice, assetId, gasLimit.toNumber());
+      gelatoEstimatedFee = await this.calculateGelatoFee(
+        chainIdForGasPrice,
+        assetId,
+        gasLimit.toNumber(),
+        parseInt(gasEstimate),
+      );
       gelatoEstimatedFee = gelatoEstimatedFee
         ? decimals > inputDecimals
           ? gelatoEstimatedFee.mul(BigNumber.from(10).pow(decimals - inputDecimals))
@@ -567,12 +572,14 @@ export class ChainReader {
    * @param chainId - ID of the chain for which this call is related.
    * @param assetId - The asset address on destination chain.
    * @param gasLimit - The gas limit to estimate.
+   * @param gasLimitL1 - The gas limit on L1 to estimate (only used on Optimism).
    * @param isHighPriority - Flag to bump the estimated fee to have more priority.
    */
   protected async calculateGelatoFee(
     chainId: number,
     assetId: string,
     gasLimit: number,
+    gasLimitL1 = 0,
     isHighPriority = false,
   ): Promise<BigNumber | undefined> {
     const gelatoOracleActive = await isOracleActive(chainId);
@@ -581,7 +588,7 @@ export class ChainReader {
     if (gelatoOracleActive) {
       const tokenSupportedByGelato = await isPaymentTokenSupported(chainId, assetId);
       if (tokenSupportedByGelato) {
-        gelatoEstimatedFee = await getEstimatedFee(chainId, assetId, gasLimit, isHighPriority);
+        gelatoEstimatedFee = await getEstimatedFee(chainId, assetId, gasLimit, isHighPriority, gasLimitL1);
       }
     }
 

--- a/packages/utils/src/gelato.ts
+++ b/packages/utils/src/gelato.ts
@@ -13,7 +13,7 @@ const gelatoSend = async (
   token: string,
   relayerFee: string,
 ): Promise<any> => {
-  const params = { dest, data, token, relayerFee};
+  const params = { dest, data, token, relayerFee };
 
   let output;
   try {
@@ -49,22 +49,21 @@ const getGelatoRelayChains = async (): Promise<string[]> => {
   try {
     const res = await axios.get(`${gelatoServer}/relays/`);
     result = res.data.relays;
-  }
-  catch(error){
+  } catch (error) {
     console.error(error);
   }
 
   return result;
 };
 
-
 const getEstimatedFee = async (
   chainId: number,
   paymentToken: string,
   gasLimit: number,
   isHighPriority: boolean,
+  gasLimitL1 = 0,
 ): Promise<BigNumber> => {
-  const result = await _getEstimatedFee(chainId, paymentToken, gasLimit, isHighPriority);
+  const result = await _getEstimatedFee(chainId, paymentToken, gasLimit, isHighPriority, gasLimitL1);
   return result;
 };
 
@@ -73,17 +72,17 @@ const _getEstimatedFee = async (
   paymentToken: string,
   gasLimit: number,
   isHighPriority: boolean,
+  gasLimitL1: number,
 ): Promise<BigNumber> => {
-  const params = {paymentToken, gasLimit, isHighPriority};
+  const params = { paymentToken, gasLimit, isHighPriority, gasLimitL1 };
   let result: BigNumber;
   try {
-    const res = await axios.get(`${gelatoServer}/oracles/${chainId}/estimate`, {params});
+    const res = await axios.get(`${gelatoServer}/oracles/${chainId}/estimate`, { params });
     result = BigNumber.from(res.data.estimatedFee);
-  }
-  catch(error){
+  } catch (error) {
     let message: string = (error as Error).message;
-    if (axios.isAxiosError(error) && error.response){
-      message = error.response?.data; 
+    if (axios.isAxiosError(error) && error.response) {
+      message = error.response?.data;
     }
     throw new Error(message);
   }
@@ -100,14 +99,12 @@ const getGelatoOracles = async (): Promise<string[]> => {
   try {
     const res = await axios.get(`${gelatoServer}/oracles/`);
     result = res.data.oracles;
-  }
-  catch(error){
+  } catch (error) {
     console.error(error);
   }
 
   return result;
 };
-
 
 const isPaymentTokenSupported = async (chainId: number, token: string): Promise<boolean> => {
   const paymentTokens = await getPaymentTokens(chainId);
@@ -120,9 +117,7 @@ const isPaymentTokenSupported = async (chainId: number, token: string): Promise<
 const getPaymentTokens = async (chainId: number): Promise<string[]> => {
   let result = [];
   try {
-    const res = await axios.get(
-      `${gelatoServer}/oracles/${chainId}/paymentTokens/`
-    );
+    const res = await axios.get(`${gelatoServer}/oracles/${chainId}/paymentTokens/`);
     result = res.data.paymentTokens;
   } catch (error) {
     console.error(error);
@@ -131,4 +126,12 @@ const getPaymentTokens = async (chainId: number): Promise<string[]> => {
   return result;
 };
 
-export { gelatoFulfill, isChainSupportedByGelato, gelatoSend, isOracleActive, getEstimatedFee, getPaymentTokens, isPaymentTokenSupported };
+export {
+  gelatoFulfill,
+  isChainSupportedByGelato,
+  gelatoSend,
+  isOracleActive,
+  getEstimatedFee,
+  getPaymentTokens,
+  isPaymentTokenSupported,
+};


### PR DESCRIPTION
## The Problem

The Gelato oracle on Optimism was not having into account the GasLimit on L1 to calculate the estimated fee

## The Solution

I added the GasLimit for L1 on the oracle request in the _gelato.ts_ file.  

Moreover I changed the function _calculateGelatoFee()_ in the _chainreader.ts_ at the txservice to accept the pre-calculated gas limit L1 as additional parameter to estimate the gas.

## Checklist

- [x] Test manually on `test-ui` using remote chains.
- [x] Run load tests.
- [ ] Update documentation if needed.
- [ ] Update CHANGELOG.md.
