### PR TITLE
[sequencer] Validate router signature is correct

### DIFF
--- a/packages/agents/sequencer/src/lib/errors/bid.ts
+++ b/packages/agents/sequencer/src/lib/errors/bid.ts
@@ -21,3 +21,13 @@ export class MissingXCall extends NxtpError {
     );
   }
 }
+
+export class InvalidRouterSignature extends NxtpError {
+  constructor(transferId: string, pathLength: string, router: string, recovered: string, context: any = {}) {
+    super(
+      "The router signature under the given path length for this bid is invalid.",
+      { transferId, pathLength, router, recovered, ...context },
+      InvalidRouterSignature.name,
+    );
+  }
+}

--- a/packages/agents/sequencer/src/lib/helpers/auctions.ts
+++ b/packages/agents/sequencer/src/lib/helpers/auctions.ts
@@ -1,4 +1,9 @@
-import { Bid, ExecuteArgs, XTransfer } from "@connext/nxtp-utils";
+import {
+  Bid,
+  ExecuteArgs,
+  XTransfer,
+  recoverRouterPathPayload as _recoverRouterPathPayload,
+} from "@connext/nxtp-utils";
 
 import { getContext } from "../../sequencer";
 
@@ -56,3 +61,5 @@ export const getDestinationLocalAsset = async (
   const localAddress = destinationDomainAsset!.local;
   return localAddress;
 };
+
+export const recoverRouterPathPayload = _recoverRouterPathPayload;

--- a/packages/agents/sequencer/src/lib/helpers/index.ts
+++ b/packages/agents/sequencer/src/lib/helpers/index.ts
@@ -1,5 +1,5 @@
 import { gelatoSend, isChainSupportedByGelato, getGelatoRelayerAddress } from "./relayer";
-import { encodeExecuteFromBids, getDestinationLocalAsset } from "./auctions";
+import { encodeExecuteFromBids, getDestinationLocalAsset, recoverRouterPathPayload } from "./auctions";
 
 export const getHelpers = () => {
   return {
@@ -11,6 +11,7 @@ export const getHelpers = () => {
     auctions: {
       encodeExecuteFromBids,
       getDestinationLocalAsset,
+      recoverRouterPathPayload,
     },
   };
 };

--- a/packages/agents/sequencer/src/lib/operations/auctions.ts
+++ b/packages/agents/sequencer/src/lib/operations/auctions.ts
@@ -9,7 +9,6 @@ import {
   getNtpTimeSeconds,
   Auction,
   jsonifyError,
-  recoverRouterPathPayload,
 } from "@connext/nxtp-utils";
 
 import { AuctionExpired, InvalidRouterSignature, MissingXCall, ParamsInvalid } from "../errors";
@@ -23,6 +22,9 @@ export const storeBid = async (bid: Bid, _requestContext: RequestContext): Promi
     logger,
     adapters: { cache, subgraph },
   } = getContext();
+  const {
+    auctions: { recoverRouterPathPayload },
+  } = getHelpers();
   const { requestContext, methodContext } = createLoggingContext(storeBid.name, _requestContext);
   logger.debug(`Method start: ${storeBid.name}`, requestContext, methodContext, { bid });
 


### PR DESCRIPTION
added a sanity check validation step: upon receiving a new bid, the sequencer should ensure router's signature(s) on given payload will recover router's address