### PR TITLE
fix: burn from handler not from user

### DIFF
--- a/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
+++ b/packages/deployments/contracts/contracts/lib/Connext/ConnextLogic.sol
@@ -845,7 +845,7 @@ library ConnextLogic {
       // if the token originates on a remote chain,
       // burn the representation tokens on this chain
       if (_amount > 0) {
-        token.burn(msg.sender, _amount);
+        token.burn(address(this), _amount);
       }
       detailsHash = token.detailsHash();
     }


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Burning from user after transferring funds to contract when it should be burning from contract

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

User no longer gets charged 2x for a transfer on non-canonical chains

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
