### PR TITLE
1280 production testnet subgraphs and db are out of sync

### DIFF
--- a/packages/agents/backend/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/backend/poller/src/lib/operations/transfers.ts
@@ -90,11 +90,17 @@ export const updateTransfers = async () => {
 
     if (xcalledTransfers.concat(executedTransfers).concat(reconciledTransfers).length == 0) {
       done = true;
-      logger.debug("Processed all pending transfers. Last page", requestContext, methodContext, { page });
+      logger.debug("Processed all pending transfers. Last page", requestContext, methodContext, {
+        lastPage: page,
+        pageSize: PAGE_SIZE,
+      });
     }
     xcalledTransfers = [];
     executedTransfers = [];
     reconciledTransfers = [];
-    logger.debug("Processed pending transfers for page", requestContext, methodContext, { page });
+    logger.debug("Processed pending transfers for page", requestContext, methodContext, {
+      lastPage: page,
+      pageSize: PAGE_SIZE,
+    });
   }
 };

--- a/packages/agents/backend/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/backend/poller/src/lib/operations/transfers.ts
@@ -90,9 +90,11 @@ export const updateTransfers = async () => {
 
     if (xcalledTransfers.concat(executedTransfers).concat(reconciledTransfers).length == 0) {
       done = true;
+      logger.debug("Processed all pending transfers. Last page", requestContext, methodContext, { page });
     }
     xcalledTransfers = [];
     executedTransfers = [];
     reconciledTransfers = [];
+    logger.debug("Processed pending transfers for page", requestContext, methodContext, { page });
   }
 };


### PR DESCRIPTION
## Description

Transfer data in the DB and subgraph are out of sync for a prolonged period. poller poll loop not functioning properly.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

`Connextscan` UI should not be out of sync with subgraphs.

## Related Issue(s)

Fixes: https://github.com/connext/nxtp/issues/1280

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
