### PR TITLE
1292 router owner withdraw

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/RoutersFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/RoutersFacet.sol
@@ -419,21 +419,6 @@ contract RoutersFacet is BaseConnextFacet {
   }
 
   /**
-   * @notice This is used by any router to decrease their available liquidity for a given asset.
-   * @param _amount - The amount of liquidity to remove for the router
-   * @param _local - The address of the asset you're removing liquidity from. If removing liquidity of the
-   * native asset, routers may use `address(0)` or the wrapped asset
-   * @param _to The address that will receive the liquidity being removed
-   */
-  function removeRouterLiquidity(
-    uint256 _amount,
-    address _local,
-    address payable _to
-  ) external nonReentrant {
-    _removeLiquidityForRouter(_amount, _local, _to, msg.sender);
-  }
-
-  /**
    * @notice This is used by any router owner to decrease their available liquidity for a given asset.
    * @param _amount - The amount of liquidity to remove for the router
    * @param _local - The address of the asset you're removing liquidity from. If removing liquidity of the
@@ -452,6 +437,21 @@ contract RoutersFacet is BaseConnextFacet {
 
     // Remove liquidity
     _removeLiquidityForRouter(_amount, _local, _to, _router);
+  }
+
+  /**
+   * @notice This is used by any router to decrease their available liquidity for a given asset.
+   * @param _amount - The amount of liquidity to remove for the router
+   * @param _local - The address of the asset you're removing liquidity from. If removing liquidity of the
+   * native asset, routers may use `address(0)` or the wrapped asset
+   * @param _to The address that will receive the liquidity being removed
+   */
+  function removeRouterLiquidity(
+    uint256 _amount,
+    address _local,
+    address payable _to
+  ) external nonReentrant {
+    _removeLiquidityForRouter(_amount, _local, _to, msg.sender);
   }
 
   // ============ Internal functions ============
@@ -521,17 +521,22 @@ contract RoutersFacet is BaseConnextFacet {
     // Sanity check: nonzero amounts
     if (_amount == 0) revert RoutersFacet__removeRouterLiquidity_amountIsZero();
 
-    uint256 routerBalance = s.routerBalances[_router][_local];
+    // Get the local key
+    address key = _local == address(0) ? address(s.wrapper) : _local;
+
+    // Get existing router balance
+    uint256 routerBalance = s.routerBalances[_router][key];
+
     // Sanity check: amount can be deducted for the router
     if (routerBalance < _amount) revert RoutersFacet__removeRouterLiquidity_insufficientFunds();
 
     // Update router balances
     unchecked {
-      s.routerBalances[_router][_local] = routerBalance - _amount;
+      s.routerBalances[_router][key] = routerBalance - _amount;
     }
 
     // Transfer from contract to specified to
-    AssetLogic.transferAssetFromContract(_local, recipient, _amount);
+    AssetLogic.transferAssetFromContract(key, recipient, _amount);
 
     // Emit event
     emit RouterLiquidityRemoved(_router, recipient, _local, _amount, msg.sender);

--- a/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
@@ -196,6 +196,13 @@ interface IConnextHandler {
 
   function addRouterLiquidity(uint256 _amount, address _local) external payable;
 
+  function removeRouterLiquidityFor(
+    uint256 _amount,
+    address _local,
+    address payable _to,
+    address _router
+  ) external;
+
   function removeRouterLiquidity(
     uint256 _amount,
     address _local,

--- a/packages/deployments/contracts/contracts_forge/utils/Deployer.sol
+++ b/packages/deployments/contracts/contracts_forge/utils/Deployer.sol
@@ -169,7 +169,7 @@ contract Deployer {
   }
 
   function getRoutersFacetCut(address _routersFacet) internal pure returns (IDiamondCut.FacetCut memory) {
-    bytes4[] memory routersFacetSelectors = new bytes4[](19);
+    bytes4[] memory routersFacetSelectors = new bytes4[](20);
     routersFacetSelectors[0] = RoutersFacet.LIQUIDITY_FEE_NUMERATOR.selector;
     routersFacetSelectors[1] = RoutersFacet.LIQUIDITY_FEE_DENOMINATOR.selector;
     routersFacetSelectors[2] = RoutersFacet.getRouterApproval.selector;
@@ -189,6 +189,7 @@ contract Deployer {
     routersFacetSelectors[16] = RoutersFacet.addRouterLiquidityFor.selector;
     routersFacetSelectors[17] = RoutersFacet.addRouterLiquidity.selector;
     routersFacetSelectors[18] = RoutersFacet.removeRouterLiquidity.selector;
+    routersFacetSelectors[19] = RoutersFacet.removeRouterLiquidityFor.selector;
     return
       IDiamondCut.FacetCut({
         facetAddress: _routersFacet,

--- a/packages/deployments/contracts/contracts_forge/utils/ForgeHelper.sol
+++ b/packages/deployments/contracts/contracts_forge/utils/ForgeHelper.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.11;
 
-import "../../lib/forge-std/src/Test.sol";
-import "../../lib/forge-std/src/console.sol";
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
 
 abstract contract ForgeHelper is Test {
   using stdStorage for StdStorage;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Updates the contracts to allow a router owner to remove liquidity on behalf of a router.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

Previously, only `router`s could call `removeLiquidity`. Now the `router` or `routerOwner` has the ability to do that.

## Related Issue(s)

Fixes #1292 

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
