### PR TITLE
1321 relayer fee params

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
@@ -291,7 +291,7 @@ contract BridgeFacet is BaseConnextFacet {
    * @notice Performs some sanity checks for `xcall`
    * @dev Need this to prevent stack too deep
    */
-  function _xcallSanityChecks(XCallArgs calldata _args) internal {
+  function _xcallSanityChecks(XCallArgs calldata _args) internal view {
     // ensure this is the right domain
     if (_args.params.originDomain != s.domain) {
       revert BridgeFacet__xcall_wrongDomain();
@@ -345,7 +345,12 @@ contract BridgeFacet is BaseConnextFacet {
     );
 
     // swap to the local asset from adopted
-    (uint256 bridgedAmt, address bridged) = AssetLogic.swapToLocalAssetIfNeeded(canonical, transactingAssetId, amount);
+    (uint256 bridgedAmt, address bridged) = AssetLogic.swapToLocalAssetIfNeeded(
+      canonical,
+      transactingAssetId,
+      amount,
+      _args.params.slippageTol
+    );
 
     bytes32 transferId = _getTransferId(_args, canonical);
 
@@ -629,7 +634,7 @@ contract BridgeFacet is BaseConnextFacet {
     }
 
     // swap out of mad* asset into adopted asset if needed
-    return AssetLogic.swapFromLocalAssetIfNeeded(_args.local, toSwap);
+    return AssetLogic.swapFromLocalAssetIfNeeded(_args.local, toSwap, _args.params.slippageTol);
   }
 
   /**

--- a/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
@@ -235,7 +235,7 @@ contract BridgeFacet is BaseConnextFacet {
     (bytes32 transferId, bytes memory message, XCalledEventArgs memory eventArgs) = _xcallProcess(_args);
 
     // Store the relayer fee
-    s.relayerFees[transferId] = _args.relayerFee;
+    s.relayerFees[transferId] = _args.params.relayerFee;
 
     // emit event
     emit XCalled(transferId, _args, eventArgs, s.nonce, message, msg.sender);
@@ -389,7 +389,7 @@ contract BridgeFacet is BaseConnextFacet {
     (, uint256 amount) = AssetLogic.handleIncomingAsset(
       _args.transactingAssetId,
       _args.amount,
-      _args.relayerFee + _args.params.callbackFee
+      _args.params.relayerFee + _args.params.callbackFee
     );
 
     // swap to the local asset from adopted
@@ -735,7 +735,7 @@ contract BridgeFacet is BaseConnextFacet {
       // Should dust the recipient with the lesser of a vault-defined cap or the converted relayer fee
       // If there is no conversion available (i.e. no oracles for origin domain asset <> dest asset pair),
       // then the vault should just pay out the configured constant
-      s.sponsorVault.reimburseRelayerFees(_args.params.originDomain, payable(_args.params.to), _args.relayerFee);
+      s.sponsorVault.reimburseRelayerFees(_args.params.originDomain, payable(_args.params.to), _args.params.relayerFee);
     }
 
     // execute the the transaction

--- a/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
@@ -120,6 +120,12 @@ contract BridgeFacet is BaseConnextFacet {
   event TransferRelayerFeesUpdated(bytes32 indexed transferId, uint256 relayerFee, address caller);
 
   /**
+   * @notice Emitted when a transfer will accept the local asset instead of the
+   * previously specified adopted asset.
+   * @param transferId - The unique identifier of the crosschain transaction
+   * @param canonicalId - The canonical identifier for the local asset
+   * @param canonicalDomain - The canonical domain for the local asset
+   * @param amount - The amount for the transfer
    */
   event ForcedReceiveLocal(
     bytes32 indexed transferId,
@@ -295,8 +301,16 @@ contract BridgeFacet is BaseConnextFacet {
   }
 
   /**
-   * @notice Anyone can call this function on the origin domain to increase the relayer fee for a transfer.
-   * @param _params - The unique identifier of the crosschain transaction
+   * @notice A user-specified agent can call this to accept the local asset instead of the
+   * previously specified adopted asset.
+   * @dev Should be called in situations where transfers are facing unfavorable slippage
+   * conditions for extended periods
+   * @param _params - The call params for the transaction
+   * @param _amount - The amount of transferring asset the tx called xcall with
+   * @param _nonce - The nonce for the transfer
+   * @param _canonicalId - The identifier of the canonical asseted associated with the transfer
+   * @param _canonicalDomain - The domain of the canonical asseted associated with the transfer
+   * @param _originSender - The msg.sender of the origin call
    */
   function forceReceiveLocal(
     CallParams calldata _params,

--- a/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
@@ -48,7 +48,7 @@ contract BridgeFacet is BaseConnextFacet {
   error BridgeFacet__xcall_callbackNotAContract();
   error BridgeFacet__reconcile_invalidAction();
   error BridgeFacet__reconcile_alreadyReconciled();
-  error BridgeFacet__execute_unapprovedRelayer();
+  error BridgeFacet__execute_unapprovedSender();
   error BridgeFacet__execute_maxRoutersExceeded();
   error BridgeFacet__execute_notSupportedRouter();
   error BridgeFacet__execute_invalidRouterSignature();
@@ -518,10 +518,10 @@ contract BridgeFacet is BaseConnextFacet {
    * @notice Performs some sanity checks for `execute`
    * @dev Need this to prevent stack too deep
    */
-  function _executeSanityChecks(ExecuteArgs calldata _args) private returns (bytes32, bool) {
+  function _executeSanityChecks(ExecuteArgs calldata _args) private view returns (bytes32, bool) {
     // If the sender is not approved relayer, revert()
-    if (!s.approvedRelayers[msg.sender]) {
-      revert BridgeFacet__execute_unapprovedRelayer();
+    if (!s.approvedRelayers[msg.sender] && msg.sender != _args.params.agent) {
+      revert BridgeFacet__execute_unapprovedSender();
     }
 
     // get number of facilitating routers

--- a/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
@@ -8,7 +8,7 @@ import {RelayerFeeRouter} from "../../relayer-fee/RelayerFeeRouter.sol";
 import {PromiseRouter} from "../../promise/PromiseRouter.sol";
 
 import {ConnextMessage} from "../libraries/ConnextMessage.sol";
-import {XCallArgs, ExecuteArgs} from "../libraries/LibConnextStorage.sol";
+import {XCallArgs, ExecuteArgs, CallParams} from "../libraries/LibConnextStorage.sol";
 import {SwapUtils} from "../libraries/SwapUtils.sol";
 
 import {IStableSwap} from "./IStableSwap.sol";
@@ -89,6 +89,15 @@ interface IConnextHandler {
   function execute(ExecuteArgs calldata _args) external returns (bytes32 transferId);
 
   function bumpTransfer(bytes32 _transferId) external payable;
+
+  function forceReceiveLocal(
+    CallParams calldata _params,
+    uint256 _amount,
+    uint256 _nonce,
+    bytes32 _canonicalId,
+    uint32 _canonicalDomain,
+    address _originSender
+  ) external payable;
 
   // NomadFacet
   function xAppConnectionManager() external view returns (XAppConnectionManager);

--- a/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
+++ b/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
@@ -275,6 +275,14 @@ struct AppStorage {
    */
   // 32
   mapping(bytes32 => mapping(address => uint8)) tokenIndexes;
+  //
+  // BridgeFacet (cont.) TODO: can we move this
+  //
+  /**
+   * @notice Stores whether a transfer has had `receiveLocal` overrides forced
+   */
+  // 33
+  mapping(bytes32 => bool) receiveLocalOverrides;
 }
 
 library LibConnextStorage {

--- a/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
+++ b/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
@@ -32,6 +32,7 @@ import {SwapUtils} from "./SwapUtils.sol";
  * @param callbackFee - The relayer fee to execute the callback
  * @param forceSlow - If true, will take slow liquidity path even if it is not a permissioned call
  * @param receiveLocal - If true, will use the local nomad asset on the destination instead of adopted.
+ * @param slippageTol - Max bps of original due to slippage (i.e. would be 9995 to tolerate .05% slippage)
  */
 struct CallParams {
   address to;
@@ -44,6 +45,7 @@ struct CallParams {
   uint256 callbackFee;
   bool forceSlow;
   bool receiveLocal;
+  uint256 slippageTol;
 }
 
 /**

--- a/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
+++ b/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
@@ -26,6 +26,7 @@ import {SwapUtils} from "./SwapUtils.sol";
  * @param callData - The data to execute on the receiving chain. If no crosschain call is needed, then leave empty.
  * @param originDomain - The originating domain (i.e. where `xcall` is called). Must match nomad domain schema
  * @param destinationDomain - The final domain (i.e. where `execute` / `reconcile` are called). Must match nomad domain schema
+ * @param agent - An address who can execute txs on behalf of `to`, in addition to allowing relayers
  * @param recovery - The address to send funds to if your `Executor.execute call` fails
  * @param callback - The address on the origin domain of the callback contract
  * @param callbackFee - The relayer fee to execute the callback
@@ -37,6 +38,7 @@ struct CallParams {
   bytes callData;
   uint32 originDomain;
   uint32 destinationDomain;
+  address agent;
   address recovery;
   address callback;
   uint256 callbackFee;

--- a/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
+++ b/packages/deployments/contracts/contracts/core/connext/libraries/LibConnextStorage.sol
@@ -32,6 +32,7 @@ import {SwapUtils} from "./SwapUtils.sol";
  * @param callbackFee - The relayer fee to execute the callback
  * @param forceSlow - If true, will take slow liquidity path even if it is not a permissioned call
  * @param receiveLocal - If true, will use the local nomad asset on the destination instead of adopted.
+ * @param relayerFee - The amount of relayer fee the tx called xcall with
  * @param slippageTol - Max bps of original due to slippage (i.e. would be 9995 to tolerate .05% slippage)
  */
 struct CallParams {
@@ -43,6 +44,7 @@ struct CallParams {
   address recovery;
   address callback;
   uint256 callbackFee;
+  uint256 relayerFee;
   bool forceSlow;
   bool receiveLocal;
   uint256 slippageTol;
@@ -54,13 +56,11 @@ struct CallParams {
  * @param transactingAssetId - The asset the caller sent with the transfer. Can be the adopted, canonical,
  * or the representational asset
  * @param amount - The amount of transferring asset the tx called xcall with
- * @param relayerFee - The amount of relayer fee the tx called xcall with
  */
 struct XCallArgs {
   CallParams params;
   address transactingAssetId; // Could be adopted, local, or wrapped
   uint256 amount;
-  uint256 relayerFee;
 }
 
 /**
@@ -71,7 +71,6 @@ struct XCallArgs {
  * @param routers - The routers who you are sending the funds on behalf of
  * @param amount - The amount of liquidity the router provided or the bridge forwarded, depending on
  * if fast liquidity was used
- * @param relayerFee - The relayer fee amount
  * @param nonce - The nonce used to generate transfer id
  * @param originSender - The msg.sender of the xcall on origin domain
  */
@@ -80,7 +79,6 @@ struct ExecuteArgs {
   address local; // local representation of canonical token
   address[] routers;
   bytes[] routerSignatures;
-  uint256 relayerFee;
   uint256 amount;
   uint256 nonce;
   address originSender;

--- a/packages/deployments/contracts/contracts/test/DummySwap.sol
+++ b/packages/deployments/contracts/contracts/test/DummySwap.sol
@@ -68,7 +68,8 @@ contract DummySwap is IStableSwap {
   }
 
   function getTokenIndex(address tokenAddress) external view returns (uint8) {
-    require(false, "!implemented");
+    return uint8(1);
+    // require(false, "!implemented");
   }
 
   function getTokenBalance(uint8 index) external view returns (uint256) {
@@ -84,15 +85,21 @@ contract DummySwap is IStableSwap {
     uint8 tokenIndexTo,
     uint256 dx
   ) external view returns (uint256) {
-    require(false, "!implemented");
+    // return 1:1
+    return dx;
   }
 
   function calculateTokenAmount(uint256[] calldata amounts, bool deposit) external view returns (uint256) {
-    require(false, "!implemented");
+    return amounts[0];
+    // require(false, "!implemented");
   }
 
   function calculateRemoveLiquidity(uint256 amount) external view returns (uint256[] memory) {
-    require(false, "!implemented");
+    // require(false, "!implemented");
+    uint256[] memory ret = new uint256[](2);
+    ret[0] = amount;
+    ret[1] = amount;
+    return ret;
   }
 
   function calculateRemoveLiquidityOneToken(uint256 tokenAmount, uint8 tokenIndex)
@@ -100,7 +107,8 @@ contract DummySwap is IStableSwap {
     view
     returns (uint256 availableTokenAmount)
   {
-    require(false, "!implemented");
+    availableTokenAmount = tokenAmount;
+    // require(false, "!implemented");
   }
 
   function initialize(
@@ -131,7 +139,8 @@ contract DummySwap is IStableSwap {
     uint256 minToMint,
     uint256 deadline
   ) external returns (uint256) {
-    require(false, "!implemented");
+    return amounts[0];
+    // require(false, "!implemented");
   }
 
   function removeLiquidity(
@@ -139,7 +148,8 @@ contract DummySwap is IStableSwap {
     uint256[] calldata minAmounts,
     uint256 deadline
   ) external returns (uint256[] memory) {
-    require(false, "!implemented");
+    return minAmounts;
+    // require(false, "!implemented");
   }
 
   function removeLiquidityOneToken(
@@ -148,7 +158,8 @@ contract DummySwap is IStableSwap {
     uint256 minAmount,
     uint256 deadline
   ) external returns (uint256) {
-    require(false, "!implemented");
+    return tokenAmount;
+    // require(false, "!implemented");
   }
 
   function removeLiquidityImbalance(

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -305,7 +305,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -337,7 +338,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -348,7 +350,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
     // TODO Correctly calculate the message
     // Harcoded the message from the emitted event since here we are only testing that relayerFee is included
     bytes
-      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70a6cbe2fbf9da0e95e9e53222cfa0bb4c24971d478546f1e0d84d27b5ccef2074d";
+      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70a99abcdc4a573fee029d9137bb672649fcdf7fd2a2195d7c253c050cf7f569d14";
 
     // NOTE: the `amount` and `bridgedAmt` are 0 because `.balanceOf` of the origin asset returns
     // 0 always via setup function
@@ -381,7 +383,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -413,7 +416,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -443,7 +447,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -479,7 +484,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -510,7 +516,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -549,7 +556,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       callbackAddr,
       callbackFee,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -588,7 +596,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       callbackAddr,
       callbackFee,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -625,7 +634,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       callbackAddr,
       callbackFee,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 
@@ -663,7 +673,8 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       address(0),
       0,
       false,
-      false
+      false,
+      9900 // slippageTol
     );
     XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
 

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -304,11 +304,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)
@@ -337,11 +338,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)
@@ -350,7 +352,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
     // TODO Correctly calculate the message
     // Harcoded the message from the emitted event since here we are only testing that relayerFee is included
     bytes
-      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70a99abcdc4a573fee029d9137bb672649fcdf7fd2a2195d7c253c050cf7f569d14";
+      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70a4de7a8656d0e86307df9d3f1ea3078387997db625b68c9005030eb3b4c29680b";
 
     // NOTE: the `amount` and `bridgedAmt` are 0 because `.balanceOf` of the origin asset returns
     // 0 always via setup function
@@ -382,11 +384,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)
@@ -415,11 +418,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)
@@ -446,11 +450,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(wrapper)), domain, amount)
@@ -483,11 +488,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     vm.expectRevert(abi.encodeWithSelector(AssetLogic.AssetLogic__handleIncomingAsset_ethWithErcTransfer.selector));
     connextHandler.xcall{value: 0}(args);
@@ -515,11 +521,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     vm.mockCall(
       address(tokenRegistry),
@@ -555,11 +562,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       callbackAddr,
       callbackFee,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     vm.mockCall(
       address(tokenRegistry),
@@ -595,11 +603,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       callbackAddr,
       callbackFee,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     vm.mockCall(
       address(tokenRegistry),
@@ -633,11 +642,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       callbackAddr,
       callbackFee,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)
@@ -672,11 +682,12 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       to,
       address(0),
       0,
+      relayerFee,
       false,
       false,
       9900 // slippageTol
     );
-    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount, relayerFee);
+    XCallArgs memory args = XCallArgs(callParams, transactingAssetId, amount);
 
     bytes32 id = keccak256(
       abi.encode(0, callParams, address(this), bytes32(abi.encodePacked(canonical)), domain, amount)

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -63,6 +63,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
   address tokenRegistry = address(2);
   address kakaroto = address(3);
   bytes32 internal remote = "remote";
+  address agent = address(123456654321);
 
   IConnextHandler connextHandler;
   MockRelayerFeeRouter relayerFeeRouter;
@@ -299,6 +300,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -330,6 +332,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes(""),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -345,7 +348,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
     // TODO Correctly calculate the message
     // Harcoded the message from the emitted event since here we are only testing that relayerFee is included
     bytes
-      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70ad61794aecac5d0f4ed6bde473107a4beda948af71d3d89b8a1572e2b7b6bd389";
+      memory message = hex"00000001000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea030000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000020b4b2eeb4ea213a5e7d1e1d2a3a1a437fbe7c8b3490898b0474b0fe66dda70a6cbe2fbf9da0e95e9e53222cfa0bb4c24971d478546f1e0d84d27b5ccef2074d";
 
     // NOTE: the `amount` and `bridgedAmt` are 0 because `.balanceOf` of the origin asset returns
     // 0 always via setup function
@@ -373,6 +376,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -404,6 +408,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -433,6 +438,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -468,6 +474,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -498,6 +505,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,
@@ -536,6 +544,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       callbackAddr,
       callbackFee,
@@ -574,6 +583,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes("0x"),
       domain,
       destinationDomain,
+      agent,
       to,
       callbackAddr,
       callbackFee,
@@ -610,6 +620,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes(""),
       domain,
       destinationDomain,
+      agent,
       to,
       callbackAddr,
       callbackFee,
@@ -647,6 +658,7 @@ contract ConnextHandlerTest is ForgeHelper, Deployer {
       bytes(""),
       domain,
       destinationDomain,
+      agent,
       to,
       address(0),
       0,

--- a/packages/deployments/contracts/contracts_forge/core/connext/facets/BridgeFacet.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/facets/BridgeFacet.t.sol
@@ -61,7 +61,8 @@ contract BridgeFacetTest is BridgeFacet, FacetHelper {
       address(0), // callback
       0, // callbackFee
       false, // forceSlow
-      false // receiveLocal
+      false, // receiveLocal
+      9900 // slippageTol
     );
 
   // ============ Test set up ============

--- a/packages/deployments/contracts/contracts_forge/core/connext/facets/BridgeFacet.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/facets/BridgeFacet.t.sol
@@ -60,6 +60,7 @@ contract BridgeFacetTest is BridgeFacet, FacetHelper {
       address(11), // recovery address
       address(0), // callback
       0, // callbackFee
+      _relayerFee, // relayer fee
       false, // forceSlow
       false, // receiveLocal
       9900 // slippageTol
@@ -127,7 +128,7 @@ contract BridgeFacetTest is BridgeFacet, FacetHelper {
     }
     // get args
     bytes[] memory empty = new bytes[](0);
-    ExecuteArgs memory args = ExecuteArgs(_params, _local, routers, empty, _relayerFee, _amount, _nonce, _originSender);
+    ExecuteArgs memory args = ExecuteArgs(_params, _local, routers, empty, _amount, _nonce, _originSender);
     // generate transfer id
     bytes32 _id = getTransferIdFromExecuteArgs(args);
     // generate router signatures

--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -914,7 +914,7 @@ describe("Connext", () => {
     const relayerFee = utils.parseEther("0.00000001");
     const prepare = await originBridge
       .connect(user)
-      .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+      .xcall({ params: { ...params, relayerFee }, transactingAssetId, amount }, { value: relayerFee });
     const prepareReceipt = await prepare.wait();
 
     // Check balance of user + bridge
@@ -943,11 +943,10 @@ describe("Connext", () => {
     // Fulfill with the router
     const routerAmount = amount.mul(9995).div(10000);
     const execute = await destinationBridge.connect(router).execute({
-      params,
+      params: { ...params, relayerFee },
       nonce,
       local: local.address,
       amount,
-      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -1018,7 +1017,7 @@ describe("Connext", () => {
     const relayerFee = utils.parseEther("0.00000001");
     const prepare = await originBridge
       .connect(user)
-      .xcall({ params, transactingAssetId, amount, relayerFee }, { value: amount.add(relayerFee) });
+      .xcall({ params: { ...params, relayerFee }, transactingAssetId, amount }, { value: amount.add(relayerFee) });
     const prepareReceipt = await prepare.wait();
 
     // Check balance of user + bridge
@@ -1050,11 +1049,10 @@ describe("Connext", () => {
     // Fulfill with the router
     const routerAmount = amount.mul(9_995).div(10_000);
     const fulfill = await destinationBridge.connect(router).execute({
-      params,
+      params: { ...params, relayerFee },
       nonce,
       local: destinationAdopted.address,
       amount,
-      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -1129,7 +1127,7 @@ describe("Connext", () => {
     const relayerFee = utils.parseEther("0.00000001");
     const prepare = await originBridge
       .connect(user)
-      .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+      .xcall({ params: { ...params, relayerFee }, transactingAssetId, amount }, { value: relayerFee });
     const prepareReceipt = await prepare.wait();
 
     const xcalledTopic = bridgeFacet.filters.XCalled().topics as string[];
@@ -1143,11 +1141,10 @@ describe("Connext", () => {
 
     // Fulfill with the router
     const execute = await destinationBridge.connect(router).execute({
-      params,
+      params: { ...params, relayerFee },
       nonce,
       local: local.address,
       amount,
-      relayerFee,
       routers: [router.address],
       routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
       originSender: user.address,
@@ -1165,11 +1162,10 @@ describe("Connext", () => {
     // before reconcile
     await expect(
       destinationBridge.connect(router).execute({
-        params,
+        params: { ...params, relayerFee },
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1185,11 +1181,10 @@ describe("Connext", () => {
     // after reconcile
     await expect(
       destinationBridge.connect(router).execute({
-        params,
+        params: { ...params, relayerFee },
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1252,7 +1247,7 @@ describe("Connext", () => {
       relayerFee = utils.parseEther("0.00000001");
       const prepare = await originBridge
         .connect(user)
-        .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+        .xcall({ params: { ...params, relayerFee }, transactingAssetId, amount }, { value: relayerFee });
       const prepareReceipt = await prepare.wait();
 
       const xcalledTopic = bridgeFacet.filters.XCalled().topics as string[];
@@ -1291,11 +1286,10 @@ describe("Connext", () => {
         );
 
         const execute = await destinationBridge.connect(router).execute({
-          params,
+          params: { ...params, relayerFee },
           nonce,
           local: local.address,
           amount,
-          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1369,11 +1363,10 @@ describe("Connext", () => {
       // Reverts on router3 math subtraction
       await expect(
         destinationBridge.connect(router).execute({
-          params,
+          params: { ...params, relayerFee },
           nonce,
           local: local.address,
           amount,
-          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1385,11 +1378,10 @@ describe("Connext", () => {
 
       // Double check that now it works
       await destinationBridge.connect(router).execute({
-        params,
+        params: { ...params, relayerFee },
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: routerAddresses,
         routerSignatures,
         originSender: user.address,
@@ -1414,11 +1406,10 @@ describe("Connext", () => {
 
       await expect(
         destinationBridge.connect(router).execute({
-          params,
+          params: { ...params, relayerFee },
           nonce,
           local: local.address,
           amount: routersAmount,
-          relayerFee,
           routers: routerAddresses,
           routerSignatures,
           originSender: user.address,
@@ -1472,8 +1463,7 @@ describe("Connext", () => {
             user,
             originAdopted,
             amounts[i],
-            relayerFees[i],
-            params,
+            { ...params, relayerFee: relayerFees[i] },
             originBridge,
             bridgeFacet,
           );
@@ -1500,11 +1490,10 @@ describe("Connext", () => {
         // Execute transfers
         for (let i = 0; i < transferIds.length; i++) {
           await destinationBridge.connect(router).execute({
-            params,
+            params: { ...params, relayerFee: relayerFees[i] },
             nonce: transferIds[i].nonce,
             local: local.address,
             amount: amounts[i],
-            relayerFee: relayerFees[i],
             routers: [router.address],
             routerSignatures: [await signRouterPathPayload(transferIds[i].transferId, "1", router)],
             originSender: user.address,
@@ -1605,12 +1594,13 @@ describe("Connext", () => {
         receiveLocal: false,
         recovery: user.address,
         slippageTol: 9990,
+        relayerFee,
       };
       transactingAssetId = originAdopted.address;
 
       const prepare = await originBridge
         .connect(user)
-        .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+        .xcall({ params, transactingAssetId, amount }, { value: relayerFee });
       const prepareReceipt = await prepare.wait();
       const xcalledTopic = bridgeFacet.filters.XCalled().topics as string[];
       const originBridgeEvent = bridgeFacet.interface.parseLog(
@@ -1637,7 +1627,6 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1680,7 +1669,6 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1727,7 +1715,6 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1775,7 +1762,6 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1820,7 +1806,6 @@ describe("Connext", () => {
         nonce,
         local: local.address,
         amount,
-        relayerFee,
         routers: [router.address],
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
@@ -1864,7 +1849,6 @@ describe("Connext", () => {
           nonce,
           local: local.address,
           amount,
-          relayerFee,
           routers: [router.address],
           routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
           originSender: user.address,

--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -77,7 +77,7 @@ const executeProxyWrite = async <T extends Contract>(
 const createFixtureLoader = waffle.createFixtureLoader;
 describe("Connext", () => {
   // Get wallets
-  const [admin, router, user, router2, router3, proxyOwner] = waffle.provider.getWallets() as Wallet[];
+  const [admin, router, user, router2, router3, proxyOwner, agent] = waffle.provider.getWallets() as Wallet[];
 
   // Token scenario:
   // - user prepares in adopted on origin
@@ -901,6 +901,7 @@ describe("Connext", () => {
       callData: "0x",
       originDomain,
       destinationDomain,
+      agent: agent.address,
       callback: ZERO_ADDRESS,
       callbackFee: 0,
       forceSlow: false,
@@ -1003,6 +1004,7 @@ describe("Connext", () => {
       callData: "0x",
       originDomain,
       destinationDomain,
+      agent: agent.address,
       callback: ZERO_ADDRESS,
       callbackFee: 0,
       recovery: user.address,
@@ -1112,6 +1114,7 @@ describe("Connext", () => {
       callData: "0x",
       originDomain,
       destinationDomain,
+      agent: agent.address,
       callback: ZERO_ADDRESS,
       callbackFee: 0,
       forceSlow: false,
@@ -1198,6 +1201,7 @@ describe("Connext", () => {
       callData: "0x",
       originDomain,
       destinationDomain,
+      agent: agent.address,
       callback: ZERO_ADDRESS,
       callbackFee: 0,
       forceSlow: false,
@@ -1426,6 +1430,7 @@ describe("Connext", () => {
       callData: "0x",
       originDomain,
       destinationDomain,
+      agent: agent.address,
       callback: ZERO_ADDRESS,
       callbackFee: 0,
       forceSlow: false,
@@ -1588,6 +1593,7 @@ describe("Connext", () => {
         callData: "0x",
         originDomain,
         destinationDomain,
+        agent: agent.address,
         callback: ZERO_ADDRESS,
         callbackFee: 0,
         forceSlow: false,

--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -907,6 +907,7 @@ describe("Connext", () => {
       forceSlow: false,
       receiveLocal: false,
       recovery: user.address,
+      slippageTol: 9990,
     };
     const transactingAssetId = originAdopted.address;
     const amount = utils.parseEther("0.0001");
@@ -1010,6 +1011,7 @@ describe("Connext", () => {
       recovery: user.address,
       forceSlow: false,
       receiveLocal: false,
+      slippageTol: 9990,
     };
     const transactingAssetId = constants.AddressZero;
     const amount = utils.parseEther("0.0001");
@@ -1120,6 +1122,7 @@ describe("Connext", () => {
       forceSlow: false,
       recovery: user.address,
       receiveLocal: false,
+      slippageTol: 9990,
     };
     const transactingAssetId = originAdopted.address;
     const amount = utils.parseEther("0.0001");
@@ -1206,6 +1209,7 @@ describe("Connext", () => {
       callbackFee: 0,
       forceSlow: false,
       receiveLocal: false,
+      slippageTol: 9990,
     };
     const amount = utils.parseEther("0.001");
     let message: any;
@@ -1435,6 +1439,7 @@ describe("Connext", () => {
       callbackFee: 0,
       forceSlow: false,
       receiveLocal: false,
+      slippageTol: 9990,
     };
 
     beforeEach(async () => {
@@ -1599,6 +1604,7 @@ describe("Connext", () => {
         forceSlow: false,
         receiveLocal: false,
         recovery: user.address,
+        slippageTol: 9990,
       };
       transactingAssetId = originAdopted.address;
 

--- a/packages/deployments/contracts/test/utils.ts
+++ b/packages/deployments/contracts/test/utils.ts
@@ -10,6 +10,7 @@ import {
   providers,
   Signer,
   Wallet,
+  BigNumberish,
 } from "ethers/lib/ethers";
 
 import { abi as Erc20Abi } from "../artifacts/contracts/test/TestERC20.sol/TestERC20.json";
@@ -372,6 +373,7 @@ export const connextXCall = async (
     callbackFee: number;
     forceSlow: boolean;
     receiveLocal: boolean;
+    slippageTol: BigNumberish;
   },
   connext: ConnextHandler,
   bridgeFacet: BridgeFacet,

--- a/packages/deployments/contracts/test/utils.ts
+++ b/packages/deployments/contracts/test/utils.ts
@@ -361,7 +361,6 @@ export const connextXCall = async (
   user: Wallet,
   asset: TestERC20,
   amount: number,
-  relayerFee: number,
   params: {
     to: string;
     recovery: string;
@@ -374,6 +373,7 @@ export const connextXCall = async (
     forceSlow: boolean;
     receiveLocal: boolean;
     slippageTol: BigNumberish;
+    relayerFee: BigNumberish;
   },
   connext: ConnextHandler,
   bridgeFacet: BridgeFacet,
@@ -385,7 +385,7 @@ export const connextXCall = async (
   const transactingAssetId = asset.address;
   const prepare = await connext
     .connect(user)
-    .xcall({ params, transactingAssetId, amount, relayerFee }, { value: relayerFee });
+    .xcall({ params, transactingAssetId, amount }, { value: params.relayerFee });
   const prepareReceipt = await prepare.wait();
 
   const xcalledTopic = bridgeFacet.filters.XCalled().topics as string[];

--- a/packages/deployments/contracts/test/utils.ts
+++ b/packages/deployments/contracts/test/utils.ts
@@ -364,6 +364,7 @@ export const connextXCall = async (
   params: {
     to: string;
     recovery: string;
+    agent: string;
     callData: string;
     originDomain: number;
     destinationDomain: number;


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Moves `relayerFee` into the `CallParams` so the `SponsorVault` knows that is what corresponds to the users transfer because it is used for `transferId` generation.

**NOTE** A malicious router could try to grief the `SponsorVault` by making up fake bids for `execute`. This should be (a) penalized in the future and (b) protected against to a reasonable degree in the `SponsorVault` itself (i.e. whitelist `to`, only EOAs, ceiling, cap per address, only if address(0), etc.)

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
