### PR TITLE
stronger assertions on reconciliation for fast liq

### DIFF
--- a/packages/deployments/contracts/test/connext.spec.ts
+++ b/packages/deployments/contracts/test/connext.spec.ts
@@ -1188,7 +1188,7 @@ describe("Connext", () => {
         routerSignatures: [await signRouterPathPayload(transferId, "1", router)],
         originSender: user.address,
       }),
-    ).to.revertedWith("BridgeFacet__execute_alreadyExecuted()");
+    ).to.revertedWith("BridgeFacet__execute_alreadyReconciled()");
   });
 
   describe("multipath", () => {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

`_executeSanityChecks` were not asserting that there should be 0 routers when fast executing. Instead, they were only asserting that *if you were slow executing* there would be no routers.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

I'm so sorry alex i didn't make an issue but it's like 2 lines of code forgive me

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
