### PR TITLE
Use abort controller for timeout in fallback subgraph

### DIFF
--- a/config/tsconfig.node.json
+++ b/config/tsconfig.node.json
@@ -12,7 +12,7 @@
     // See https://node.green for node versions' support of ecmascript
     // versions and features.
     "target": "es2019",
-    "lib": ["es2019"],
+    "lib": ["es2019", "dom"],
 
     "types": ["node"]
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "docker:local:services": "yarn workspace @connext/nxtp-integration docker:services:up && bash setup-integration-test.sh"
   },
   "resolutions": {
-    "@nomiclabs/hardhat-ethers": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz"
+    "@nomiclabs/hardhat-ethers": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz",
+    "gluegun": "4.7.1"
   },
   "packageManager": "yarn@2.4.2"
 }

--- a/packages/router/src/adapters/subgraph/index.ts
+++ b/packages/router/src/adapters/subgraph/index.ts
@@ -77,12 +77,14 @@ export const subgraphContractReader = (): ContractReader => {
   Object.entries(config.chainConfig).forEach(([chainId, { subgraph, analyticsSubgraph, subgraphSyncBuffer }]) => {
     const chainIdNumber = parseInt(chainId);
 
+    const abortController = new AbortController();
     sdks[chainIdNumber] = new FallbackSubgraph<Sdk>(
       chainIdNumber,
-      (url: string) => getSdk(new GraphQLClient(url)),
+      (url: string) => getSdk(new GraphQLClient(url, { signal: abortController.signal })),
       subgraphSyncBuffer,
       SubgraphDomain.COMMON,
       subgraph,
+      abortController,
     );
 
     analyticsSdks[chainIdNumber] = new FallbackSubgraph<AnalyticsSdk>(

--- a/packages/utils/src/fallbackSubgraph.ts
+++ b/packages/utils/src/fallbackSubgraph.ts
@@ -334,7 +334,7 @@ export class FallbackSubgraph<T> {
           this.subgraphs.set(item.url, subgraph);
         });
       } else if (getBlockNumberSupported) {
-        const _latestBlock = getBlockNumber();
+        const _latestBlock = getBlockNumber!();
         await Promise.all(
           Array.from(this.subgraphs.values()).map(async (subgraph) => {
             try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6015,13 +6015,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apisauce@npm:^1.0.1":
-  version: 1.1.5
-  resolution: "apisauce@npm:1.1.5"
+"apisauce@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "apisauce@npm:2.1.5"
   dependencies:
-    axios: ^0.21.2
-    ramda: ^0.25.0
-  checksum: f1c769635bad8b391cfcb22f403db8b6eb3bacacea9ec2ecbc11b82f428bbc2776c146c9f4e8ba316c15583ba4158d822f7864f033db1c4efe7620bf367f3087
+    axios: ^0.21.4
+  checksum: 0cf9ec1b3d9ba93a5de19bdf7a7aa81f252a55f3ca51249454a3ff4b726af57a62c9e0e1ca33220c9e82224f7ca49b4fa6fe0a2e5559d9452195dbecd8528dfe
   languageName: node
   linkType: hard
 
@@ -6515,7 +6514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.2":
+"axios@npm:^0.21.4":
   version: 0.21.4
   resolution: "axios@npm:0.21.4"
   dependencies:
@@ -8951,14 +8950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:1.3.3":
-  version: 1.3.3
-  resolution: "colors@npm:1.3.3"
-  checksum: b24612249344b2179a1c242ac430ca760802ef9d0b127fdfc6db5a12beafd76882285031537856dfe3bd7c8d755eb1b4c31fffd3da40d150091919b876602fd6
-  languageName: node
-  linkType: hard
-
-"colors@npm:^1.1.2":
+"colors@npm:^1.1.2, colors@npm:^1.3.3":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
   checksum: a0f266ac041a9774d92cc9624a984707678d2eeec125d54e8d8231075ce36c24c5352fb5d0f90c6ee420d0f63e354417cec716386ad341309334aad18e32b933
@@ -13693,14 +13685,14 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
-  version: 4.3.1
-  resolution: "gluegun@https://github.com/edgeandnode/gluegun.git#commit=b34b9003d7bf556836da41b57ef36eb21570620a"
+"gluegun@npm:4.7.1":
+  version: 4.7.1
+  resolution: "gluegun@npm:4.7.1"
   dependencies:
-    apisauce: ^1.0.1
+    apisauce: ^2.1.5
     app-module-path: ^2.2.0
     cli-table3: ~0.5.0
-    colors: 1.3.3
+    colors: ^1.3.3
     cosmiconfig: 6.0.0
     cross-spawn: ^7.0.0
     ejs: ^2.6.1
@@ -13724,13 +13716,12 @@ fsevents@~2.1.1:
     lodash.upperfirst: ^4.3.1
     ora: ^4.0.0
     pluralize: ^8.0.0
-    ramdasauce: ^2.1.0
     semver: ^7.0.0
     which: ^2.0.0
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: d727a79afc083ce47983754ff2a128209046eb47873e3ea5ba1b7e73a9be6ea93837c916999d1810cbb31c0a1708a50eb450450a5bf393795bfb1a72510a0ac1
+  checksum: 3c7957d4f666865f38e8b861d0422e8f707b5ce81ba29d027a922d9cd781380a44c3314d53e8c8e934a008ee189b5742f2eb0d7035f8e880d31d4198be2e3bc7
   languageName: node
   linkType: hard
 
@@ -22336,29 +22327,6 @@ fsevents@~2.1.1:
   dependencies:
     performance-now: ^2.1.0
   checksum: 567b0160be46ed20b124a05ace6e653f4ad3c047c48d02ac76161e9ac624488c0fdf622b2f4fb9c35c0c828a13dfa549044ad1db89c7af075cb0f99403b88c4b
-  languageName: node
-  linkType: hard
-
-"ramda@npm:^0.24.1":
-  version: 0.24.1
-  resolution: "ramda@npm:0.24.1"
-  checksum: 29e4997164cb43973d67a02a91c902f0d62d7500e61252a88cf132466259b7f3dfa977cf971d288e2566c3bae2413e354c5890b5db574440fe081cb6c52c8af6
-  languageName: node
-  linkType: hard
-
-"ramda@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "ramda@npm:0.25.0"
-  checksum: 700b6073bc485a08ecca89871659f12487b1681e7c0d868a7768c16bc64df5cfc37e13563c64c228e525cf9d322cf89980919f15dd7e1c0265e70f48f719e9dc
-  languageName: node
-  linkType: hard
-
-"ramdasauce@npm:^2.1.0":
-  version: 2.1.3
-  resolution: "ramdasauce@npm:2.1.3"
-  dependencies:
-    ramda: ^0.24.1
-  checksum: f2bdcbfa90a19fa05a6a6eaa5f9c625853da83ab908d27b23c069cb689eac7072b428032f35243728ebe15fddfe1f65a890347072c2cccc8665923661f65e60b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

GraphQLClient supports using `AbortController`:
https://github.com/prisma-labs/graphql-request#cancellation
https://github.com/node-fetch/node-fetch#request-cancellation-with-abortsignal

This seems like a more functional way of aborting requests due to timeout than the current method (Promise.race).
