### PR TITLE
Add ability to propose (and revoke) upgrades

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/DiamondCutFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/DiamondCutFacet.sol
@@ -27,4 +27,22 @@ contract DiamondCutFacet is IDiamondCut {
     LibDiamond.enforceIsContractOwner();
     LibDiamond.diamondCut(_diamondCut, _init, _calldata);
   }
+
+  function proposeDiamondCut(
+    FacetCut[] calldata _diamondCut,
+    address _init,
+    bytes calldata _calldata
+  ) external {
+    LibDiamond.enforceIsContractOwner();
+    LibDiamond.proposeDiamondCut(_diamondCut, _init, _calldata);
+  }
+
+  function rescindDiamondCut(
+    FacetCut[] calldata _diamondCut,
+    address _init,
+    bytes calldata _calldata
+  ) external {
+    LibDiamond.enforceIsContractOwner();
+    LibDiamond.rescindDiamondCut(_diamondCut, _init, _calldata);
+  }
 }

--- a/packages/deployments/contracts/contracts/core/connext/libraries/LibDiamond.sol
+++ b/packages/deployments/contracts/contracts/core/connext/libraries/LibDiamond.sol
@@ -13,6 +13,8 @@ import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
 library LibDiamond {
   bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("diamond.standard.diamond.storage");
 
+  uint256 private constant _delay = 7 days;
+
   struct FacetAddressAndPosition {
     address facetAddress;
     uint96 functionSelectorPosition; // position in facetFunctionSelectors.functionSelectors array
@@ -36,6 +38,8 @@ library LibDiamond {
     mapping(bytes4 => bool) supportedInterfaces;
     // owner of the contract
     address contractOwner;
+    // hash of proposed facets => acceptance time
+    mapping(bytes32 => uint256) acceptanceTimes;
   }
 
   function diamondStorage() internal pure returns (DiamondStorage storage ds) {
@@ -62,6 +66,29 @@ library LibDiamond {
     require(msg.sender == diamondStorage().contractOwner, "LibDiamond: Must be contract owner");
   }
 
+  event DiamondCutProposed(IDiamondCut.FacetCut[] _diamondCut, address _init, bytes _calldata, uint256 deadline);
+
+  function proposeDiamondCut(
+    IDiamondCut.FacetCut[] memory _diamondCut,
+    address _init,
+    bytes memory _calldata
+  ) internal {
+    uint256 acceptance = block.timestamp + _delay;
+    diamondStorage().acceptanceTimes[keccak256(abi.encode(_diamondCut))] = acceptance;
+    emit DiamondCutProposed(_diamondCut, _init, _calldata, acceptance);
+  }
+
+  event DiamondCutRescinded(IDiamondCut.FacetCut[] _diamondCut, address _init, bytes _calldata);
+
+  function rescindDiamondCut(
+    IDiamondCut.FacetCut[] memory _diamondCut,
+    address _init,
+    bytes memory _calldata
+  ) internal {
+    diamondStorage().acceptanceTimes[keccak256(abi.encode(_diamondCut))] = 0;
+    emit DiamondCutRescinded(_diamondCut, _init, _calldata);
+  }
+
   event DiamondCut(IDiamondCut.FacetCut[] _diamondCut, address _init, bytes _calldata);
 
   // Internal function version of diamondCut
@@ -70,6 +97,10 @@ library LibDiamond {
     address _init,
     bytes memory _calldata
   ) internal {
+    require(
+      diamondStorage().acceptanceTimes[keccak256(abi.encode(_diamondCut))] < block.timestamp,
+      "LibDiamond: delay not elapsed"
+    );
     for (uint256 facetIndex; facetIndex < _diamondCut.length; facetIndex++) {
       IDiamondCut.FacetCutAction action = _diamondCut[facetIndex].action;
       if (action == IDiamondCut.FacetCutAction.Add) {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Need the ability to time lock upgrades to allow people to exit if a protocol multisig maliciously upgrades contracts

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

- Add `proposeDiamondCut`, `rescindDiamondCut`
- Enforces delay elapsed before accepting diamond cut upgrades

## Related Issue(s)

N/A

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
