### PR TITLE
1395 fix execute and reconcile destinations queries to subgraph

### DIFF
--- a/packages/adapters/subgraph/src/lib/operations/queries.ts
+++ b/packages/adapters/subgraph/src/lib/operations/queries.ts
@@ -311,6 +311,7 @@ export const getDestinationTransfersByExecuteTimestampQuery = (
         params.get(domain)!.fromTimestamp,
         domains,
         params.get(domain)!.maxBlockNumber,
+        params.get(domain)!.orderDirection,
       );
     } else {
       console.log(`No agents for domain: ${domain}`);
@@ -358,6 +359,7 @@ export const getDestinationTransfersByReconcileTimestampQuery = (
         params.get(domain)!.fromTimestamp,
         domains,
         params.get(domain)!.maxBlockNumber,
+        params.get(domain)!.orderDirection,
       );
     } else {
       console.log(`No agents for domain: ${domain}`);

--- a/packages/adapters/subgraph/src/lib/operations/queries.ts
+++ b/packages/adapters/subgraph/src/lib/operations/queries.ts
@@ -279,7 +279,6 @@ export const getOriginTransfersQuery = (agents: Map<string, SubgraphQueryMetaPar
 
 const destinationTransfersByExecuteTimestampQueryString = (
   prefix: string,
-  originDomain: string,
   fromTimestamp: number,
   destinationDomains: string[],
   maxBlockNumber?: number,
@@ -288,7 +287,6 @@ const destinationTransfersByExecuteTimestampQueryString = (
   return `
   ${prefix}_destinationTransfers(
     where: { 
-      originDomain: ${originDomain}, 
       executedTimestamp_gte: ${fromTimestamp}, 
       destinationDomain_in: [${destinationDomains}] 
       ${maxBlockNumber ? `, executedBlockNumber_lte: ${maxBlockNumber}` : ""} 
@@ -310,7 +308,6 @@ export const getDestinationTransfersByExecuteTimestampQuery = (
     if (params.has(domain)) {
       combinedQuery += destinationTransfersByExecuteTimestampQueryString(
         prefix,
-        domain,
         params.get(domain)!.fromTimestamp,
         domains,
         params.get(domain)!.maxBlockNumber,
@@ -329,7 +326,6 @@ export const getDestinationTransfersByExecuteTimestampQuery = (
 
 const destinationTransfersByReconcileTimestampQueryString = (
   prefix: string,
-  originDomain: string,
   fromTimestamp: number,
   destinationDomains: string[],
   maxBlockNumber?: number,
@@ -338,7 +334,6 @@ const destinationTransfersByReconcileTimestampQueryString = (
   return `
   ${prefix}_destinationTransfers(
     where: { 
-      originDomain: ${originDomain}, 
       reconciledTimestamp_gte: ${fromTimestamp}, 
       destinationDomain_in: [${destinationDomains}] 
       ${maxBlockNumber ? `, reconciledBlockNumber_lte: ${maxBlockNumber}` : ""} 
@@ -360,7 +355,6 @@ export const getDestinationTransfersByReconcileTimestampQuery = (
     if (params.has(domain)) {
       combinedQuery += destinationTransfersByReconcileTimestampQueryString(
         prefix,
-        domain,
         params.get(domain)!.fromTimestamp,
         domains,
         params.get(domain)!.maxBlockNumber,

--- a/packages/adapters/subgraph/src/lib/operations/queries.ts
+++ b/packages/adapters/subgraph/src/lib/operations/queries.ts
@@ -293,7 +293,7 @@ const destinationTransfersByExecuteTimestampQueryString = (
     }, 
     orderBy: executedTimestamp, 
     orderDirection: ${orderDirection}
-  ) {${ORIGIN_TRANSFER_ENTITY}}`;
+  ) {${DESTINATION_TRANSFER_ENTITY}}`;
 };
 
 export const getDestinationTransfersByExecuteTimestampQuery = (
@@ -340,7 +340,7 @@ const destinationTransfersByReconcileTimestampQueryString = (
     }, 
     orderBy: executedTimestamp, 
     orderDirection: ${orderDirection}
-  ) {${ORIGIN_TRANSFER_ENTITY}}`;
+  ) {${DESTINATION_TRANSFER_ENTITY}}`;
 };
 
 export const getDestinationTransfersByReconcileTimestampQuery = (

--- a/packages/agents/cartographer/poller/cartographer.config.js
+++ b/packages/agents/cartographer/poller/cartographer.config.js
@@ -6,8 +6,6 @@ module.exports = {
       kill_timeout: 1500,
       cron_restart: "*/5 * * * *",
     },
-  ],
-  apps: [
     {
       name: "routers-poller",
       script: "./dist/entryRouters.js",

--- a/packages/agents/cartographer/poller/src/adapters/database/client.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/client.ts
@@ -98,9 +98,9 @@ export const getTransfersByStatus = async (
   const poolToUse = _pool ?? pool;
   const x = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
     status,
-  }} ORDER BY "xcall_timestamp" ${raw(`${orderDirection}`)} LIMIT ${db.param(limit)} OFFSET ${db.param(offset)}`.run(
-    poolToUse,
-  );
+  }} ORDER BY "xcall_timestamp" ${raw(`${orderDirection}`)} NULLS LAST LIMIT ${db.param(limit)} OFFSET ${db.param(
+    offset,
+  )}`.run(poolToUse);
   return x.map(convertFromDbTransfer);
 };
 
@@ -108,7 +108,7 @@ export const getLatestNonce = async (domain: string, _pool?: Pool): Promise<numb
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
     origin_domain: domain,
-  }} ORDER BY "nonce" DESC LIMIT 1`.run(poolToUse);
+  }} ORDER BY "nonce" DESC NULLS LAST LIMIT 1`.run(poolToUse);
   return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
 };
 
@@ -116,7 +116,7 @@ export const getLatestExecuteTimestamp = async (domain: string, _pool?: Pool): P
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
     destination_domain: domain,
-  }} ORDER BY "execute_timestamp" DESC LIMIT 1`.run(poolToUse);
+  }} ORDER BY "execute_timestamp" DESC NULLS LAST LIMIT 1`.run(poolToUse);
   return BigNumber.from(transfer[0]?.execute_timestamp ?? 0).toNumber();
 };
 
@@ -124,7 +124,7 @@ export const getLatestReconcileTimestamp = async (domain: string, _pool?: Pool):
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
     destination_domain: domain,
-  }} ORDER BY "reconcile_timestamp" DESC LIMIT 1`.run(poolToUse);
+  }} ORDER BY "reconcile_timestamp" DESC NULLS LAST LIMIT 1`.run(poolToUse);
   return BigNumber.from(transfer[0]?.reconcile_timestamp ?? 0).toNumber();
 };
 

--- a/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
@@ -64,6 +64,7 @@ export const updateTransfers = async () => {
     const transfers = await subgraph.getOriginTransfers(subgraphQueryMetaParams);
     logger.info("Retrieved origin transfers", requestContext, methodContext, {
       transfers,
+      count: transfers.length,
     });
     await database.saveTransfers(transfers);
   }
@@ -73,6 +74,7 @@ export const updateTransfers = async () => {
     const transfers = await subgraph.getDestinationTransfersByExecuteTimestamp(subgraphExecuteQueryMetaParams);
     logger.info("Retrieved destination transfers by execute timestamp", requestContext, methodContext, {
       transfers,
+      count: transfers.length,
     });
     await database.saveTransfers(transfers);
   }
@@ -82,6 +84,7 @@ export const updateTransfers = async () => {
     const transfers = await subgraph.getDestinationTransfersByReconcileTimestamp(subgraphReconcileQueryMetaParams);
     logger.info("Retrieved destination transfers by reconcile timestamp", requestContext, methodContext, {
       transfers,
+      count: transfers.length,
     });
     await database.saveTransfers(transfers);
   }


### PR DESCRIPTION
## Description
Fixes execute and reconcile destinations queries from `cartographer`  to use latest state in db and as the starting point for queries to the subgraph.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code


## Related Issue(s)

Fixes <!--- Please link to the issue here: -->
https://github.com/connext/nxtp/issues/1395


<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
