### PR TITLE
1404 race condition in cartographer subgraph queries

### DIFF
--- a/packages/adapters/subgraph/src/reader.ts
+++ b/packages/adapters/subgraph/src/reader.ts
@@ -27,6 +27,7 @@ import {
   getLastestBlockNumberQuery,
   getDestinationTransfersByExecuteTimestampQuery,
   getDestinationTransfersByReconcileTimestampQuery,
+  getOriginTransfersByXCallTimestampQuery,
 } from "./lib/operations";
 import { SubgraphMap } from "./lib/entities";
 
@@ -275,6 +276,27 @@ export class SubgraphReader {
   public async getOriginTransfers(agents: Map<string, SubgraphQueryMetaParams>): Promise<XTransfer[]> {
     const { execute, parser } = getHelpers();
     const xcalledXQuery = getOriginTransfersQuery(agents);
+    const response = await execute(xcalledXQuery);
+
+    const transfers: any[] = [];
+    for (const key of response.keys()) {
+      const value = response.get(key);
+      transfers.push(value?.flat());
+    }
+
+    const originTransfers: XTransfer[] = transfers
+      .flat()
+      .filter((x: any) => !!x)
+      .map(parser.originTransfer);
+
+    return originTransfers;
+  }
+
+  public async getOriginTransfersByXCallTimestamp(
+    params: Map<string, SubgraphQueryByTimestampMetaParams>,
+  ): Promise<XTransfer[]> {
+    const { execute, parser } = getHelpers();
+    const xcalledXQuery = getOriginTransfersByXCallTimestampQuery(params);
     const response = await execute(xcalledXQuery);
 
     const transfers: any[] = [];

--- a/packages/agents/cartographer/poller/src/adapters/database/client.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/client.ts
@@ -112,6 +112,14 @@ export const getLatestNonce = async (domain: string, _pool?: Pool): Promise<numb
   return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
 };
 
+export const getLatestXCallTimestamp = async (domain: string, _pool?: Pool): Promise<number> => {
+  const poolToUse = _pool ?? pool;
+  const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
+    origin_domain: domain,
+  }} ORDER BY "xcall_timestamp" DESC NULLS LAST LIMIT 1`.run(poolToUse);
+  return BigNumber.from(transfer[0]?.xcall_timestamp ?? 0).toNumber();
+};
+
 export const getLatestExecuteTimestamp = async (domain: string, _pool?: Pool): Promise<number> => {
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{

--- a/packages/agents/cartographer/poller/src/adapters/database/client.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/client.ts
@@ -112,6 +112,14 @@ export const getLatestNonce = async (domain: string, _pool?: Pool): Promise<numb
   return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
 };
 
+export const getLastXCallNonce = async (domain: string, _pool?: Pool): Promise<number> => {
+  const poolToUse = _pool ?? pool;
+  const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
+    origin_domain: domain,
+  }} AND "xcall_timestamp" IS NULL ORDER BY "nonce" ASC LIMIT 1`.run(poolToUse);
+  return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
+};
+
 export const getLatestExecuteTimestamp = async (domain: string, _pool?: Pool): Promise<number> => {
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{

--- a/packages/agents/cartographer/poller/src/adapters/database/client.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/client.ts
@@ -112,14 +112,6 @@ export const getLatestNonce = async (domain: string, _pool?: Pool): Promise<numb
   return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
 };
 
-export const getLastXCallNonce = async (domain: string, _pool?: Pool): Promise<number> => {
-  const poolToUse = _pool ?? pool;
-  const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
-    origin_domain: domain,
-  }} AND "xcall_timestamp" IS NULL ORDER BY "nonce" ASC LIMIT 1`.run(poolToUse);
-  return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
-};
-
 export const getLatestExecuteTimestamp = async (domain: string, _pool?: Pool): Promise<number> => {
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{

--- a/packages/agents/cartographer/poller/src/adapters/database/client.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/client.ts
@@ -104,14 +104,6 @@ export const getTransfersByStatus = async (
   return x.map(convertFromDbTransfer);
 };
 
-export const getLatestNonce = async (domain: string, _pool?: Pool): Promise<number> => {
-  const poolToUse = _pool ?? pool;
-  const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{
-    origin_domain: domain,
-  }} ORDER BY "nonce" DESC NULLS LAST LIMIT 1`.run(poolToUse);
-  return BigNumber.from(transfer[0]?.nonce ?? 0).toNumber();
-};
-
 export const getLatestXCallTimestamp = async (domain: string, _pool?: Pool): Promise<number> => {
   const poolToUse = _pool ?? pool;
   const transfer = await db.sql<s.transfers.SQL, s.transfers.JSONSelectable[]>`SELECT * FROM ${"transfers"} WHERE ${{

--- a/packages/agents/cartographer/poller/src/adapters/database/index.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/index.ts
@@ -8,6 +8,7 @@ import {
   getTransfersByStatus,
   saveTransfers,
   saveRouterBalances,
+  getLatestXCallTimestamp,
   getLatestExecuteTimestamp,
   getLatestReconcileTimestamp,
 } from "./client";
@@ -23,6 +24,7 @@ export type Database = {
     _pool?: Pool,
   ) => Promise<XTransfer[]>;
   saveRouterBalances: (routerBalances: RouterBalance[], _pool?: Pool) => Promise<void>;
+  getLatestXCallTimestamp: (domain: string, _pool?: Pool) => Promise<number>;
   getLatestExecuteTimestamp: (domain: string, _pool?: Pool) => Promise<number>;
   getLatestReconcileTimestamp: (domain: string, _pool?: Pool) => Promise<number>;
 };
@@ -46,6 +48,7 @@ export const getDatabase = async (): Promise<Database> => {
     saveTransfers,
     getTransfersByStatus,
     saveRouterBalances,
+    getLatestXCallTimestamp,
     getLatestExecuteTimestamp,
     getLatestReconcileTimestamp,
   };

--- a/packages/agents/cartographer/poller/src/adapters/database/index.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/index.ts
@@ -5,6 +5,7 @@ import { getContext } from "../../shared";
 
 import {
   getLatestNonce,
+  getLastXCallNonce,
   getTransfersByStatus,
   saveTransfers,
   saveRouterBalances,
@@ -15,6 +16,7 @@ import {
 export type Database = {
   saveTransfers: (xtransfers: XTransfer[], _pool?: Pool) => Promise<void>;
   getLatestNonce: (domain: string, _pool?: Pool) => Promise<number>;
+  getLastXCallNonce: (domain: string, _pool?: Pool) => Promise<number>;
   getTransfersByStatus: (
     status: XTransferStatus,
     limit: number,
@@ -43,6 +45,7 @@ export const getDatabase = async (): Promise<Database> => {
 
   return {
     getLatestNonce,
+    getLastXCallNonce,
     saveTransfers,
     getTransfersByStatus,
     saveRouterBalances,

--- a/packages/agents/cartographer/poller/src/adapters/database/index.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/index.ts
@@ -5,7 +5,6 @@ import { getContext } from "../../shared";
 
 import {
   getLatestNonce,
-  getLastXCallNonce,
   getTransfersByStatus,
   saveTransfers,
   saveRouterBalances,
@@ -16,7 +15,6 @@ import {
 export type Database = {
   saveTransfers: (xtransfers: XTransfer[], _pool?: Pool) => Promise<void>;
   getLatestNonce: (domain: string, _pool?: Pool) => Promise<number>;
-  getLastXCallNonce: (domain: string, _pool?: Pool) => Promise<number>;
   getTransfersByStatus: (
     status: XTransferStatus,
     limit: number,
@@ -45,7 +43,6 @@ export const getDatabase = async (): Promise<Database> => {
 
   return {
     getLatestNonce,
-    getLastXCallNonce,
     saveTransfers,
     getTransfersByStatus,
     saveRouterBalances,

--- a/packages/agents/cartographer/poller/src/adapters/database/index.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/index.ts
@@ -4,7 +4,6 @@ import { Pool } from "pg";
 import { getContext } from "../../shared";
 
 import {
-  getLatestNonce,
   getTransfersByStatus,
   saveTransfers,
   saveRouterBalances,
@@ -15,7 +14,6 @@ import {
 
 export type Database = {
   saveTransfers: (xtransfers: XTransfer[], _pool?: Pool) => Promise<void>;
-  getLatestNonce: (domain: string, _pool?: Pool) => Promise<number>;
   getTransfersByStatus: (
     status: XTransferStatus,
     limit: number,
@@ -44,7 +42,6 @@ export const getDatabase = async (): Promise<Database> => {
   }
 
   return {
-    getLatestNonce,
     saveTransfers,
     getTransfersByStatus,
     saveRouterBalances,

--- a/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
@@ -31,12 +31,11 @@ export const updateTransfers = async () => {
     }
 
     // Retrieve latest nonce from the database; will reflect the most recent origin transfers we've saved for this domain.
-    const currentNonce = await database.getLatestNonce(domain);
-    const lastXCallNonce = await database.getLastXCallNonce(domain);
+    const latestNonce = await database.getLatestNonce(domain);
 
     subgraphQueryMetaParams.set(domain, {
       maxBlockNumber: latestBlockNumber,
-      latestNonce: lastXCallNonce < currentNonce ? lastXCallNonce : currentNonce + 1,
+      latestNonce: latestNonce == 0 ? 0 : latestNonce + 1,
       destinationDomains: domains,
       orderDirection: "asc",
     });

--- a/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
@@ -31,11 +31,12 @@ export const updateTransfers = async () => {
     }
 
     // Retrieve latest nonce from the database; will reflect the most recent origin transfers we've saved for this domain.
-    const latestNonce = await database.getLatestNonce(domain);
+    const currentNonce = await database.getLatestNonce(domain);
+    const lastXCallNonce = await database.getLastXCallNonce(domain);
 
     subgraphQueryMetaParams.set(domain, {
       maxBlockNumber: latestBlockNumber,
-      latestNonce: latestNonce == 0 ? 0 : latestNonce + 1,
+      latestNonce: lastXCallNonce < currentNonce ? lastXCallNonce : currentNonce + 1,
       destinationDomains: domains,
       orderDirection: "asc",
     });

--- a/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
@@ -1,4 +1,4 @@
-import { createLoggingContext, SubgraphQueryMetaParams, SubgraphQueryByTimestampMetaParams } from "@connext/nxtp-utils";
+import { createLoggingContext, SubgraphQueryByTimestampMetaParams } from "@connext/nxtp-utils";
 
 import { getContext } from "../../shared";
 
@@ -10,7 +10,7 @@ export const updateTransfers = async () => {
   } = getContext();
   const { requestContext, methodContext } = createLoggingContext("updateTransfers");
 
-  const subgraphQueryMetaParams: Map<string, SubgraphQueryMetaParams> = new Map();
+  const subgraphXCallQueryMetaParams: Map<string, SubgraphQueryByTimestampMetaParams> = new Map();
   const subgraphExecuteQueryMetaParams: Map<string, SubgraphQueryByTimestampMetaParams> = new Map();
   const subgraphReconcileQueryMetaParams: Map<string, SubgraphQueryByTimestampMetaParams> = new Map();
   const lastestBlockNumbers: Map<string, number> = await subgraph.getLatestBlockNumber(domains);
@@ -30,13 +30,13 @@ export const updateTransfers = async () => {
       continue;
     }
 
-    // Retrieve latest nonce from the database; will reflect the most recent origin transfers we've saved for this domain.
-    const latestNonce = await database.getLatestNonce(domain);
+    // Retrieve the most recent origin transfers we've saved for this domain.
+    const xCallTimestamp = await database.getLatestXCallTimestamp(domain);
 
-    subgraphQueryMetaParams.set(domain, {
+    subgraphXCallQueryMetaParams.set(domain, {
       maxBlockNumber: latestBlockNumber,
-      latestNonce: latestNonce == 0 ? 0 : latestNonce + 1,
       destinationDomains: domains,
+      fromTimestamp: xCallTimestamp,
       orderDirection: "asc",
     });
 
@@ -59,10 +59,10 @@ export const updateTransfers = async () => {
     });
   }
 
-  if (subgraphQueryMetaParams.size > 0) {
+  if (subgraphXCallQueryMetaParams.size > 0) {
     // Get origin transfers for all domains in the mapping.
-    const transfers = await subgraph.getOriginTransfers(subgraphQueryMetaParams);
-    logger.info("Retrieved origin transfers", requestContext, methodContext, {
+    const transfers = await subgraph.getOriginTransfersByXCallTimestamp(subgraphXCallQueryMetaParams);
+    logger.info("Retrieved origin transfers by xcalled timestamp", requestContext, methodContext, {
       transfers,
       count: transfers.length,
     });

--- a/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
+++ b/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
@@ -19,6 +19,7 @@ import {
   getLatestNonce,
   saveTransfers,
   saveRouterBalances,
+  getLatestXCallTimestamp,
   getLatestExecuteTimestamp,
   getLatestReconcileTimestamp,
 } from "../../../src/adapters/database/client";
@@ -409,6 +410,18 @@ describe("Database client", () => {
     expect(rb).to.deep.eq(routerBalances);
   });
 
+  it("should get latest xcall timestamp", async () => {
+    const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.XCalled });
+    xTransfer1.origin.xcall.timestamp = 1;
+    const xTransfer2: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.XCalled });
+    xTransfer2.origin.xcall.timestamp = 2;
+    const xTransfer3: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.XCalled });
+    xTransfer3.origin.xcall.timestamp = 3;
+    await saveTransfers([xTransfer1, xTransfer2, xTransfer3], pool);
+    const timestamp = await getLatestXCallTimestamp(xTransfer1.originDomain, pool);
+    expect(timestamp).equal(3);
+  });
+
   it("should get latest execute timestamp", async () => {
     const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
     xTransfer1.destination.execute.timestamp = 1;
@@ -437,6 +450,12 @@ describe("Database client", () => {
     const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
     const nonce = await getLatestNonce(xTransfer1.destinationDomain, pool);
     expect(nonce).equal(0);
+  });
+
+  it("should get latest xcall timestamp when no data", async () => {
+    const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.XCalled });
+    const timestamp = await getLatestXCallTimestamp(xTransfer1.originDomain, pool);
+    expect(timestamp).equal(0);
   });
 
   it("should get latest execute timestamp when no data", async () => {

--- a/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
+++ b/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
@@ -17,7 +17,6 @@ import {
   getTransferByTransferId,
   getTransfersByStatus,
   getLatestNonce,
-  getLastXCallNonce,
   saveTransfers,
   saveRouterBalances,
   getLatestExecuteTimestamp,
@@ -319,54 +318,6 @@ describe("Database client", () => {
     expect(nonce).equal(1234);
   });
 
-  it("should get last XCalled nonce", async () => {
-    const xTransfer = mock.entity.xtransfer();
-    xTransfer.origin.xcall.timestamp = undefined;
-    xTransfer.nonce = 1;
-    await saveTransfers([xTransfer], pool);
-    const xTransfer2 = mock.entity.xtransfer();
-    xTransfer2.nonce = 111;
-    await saveTransfers([xTransfer2], pool);
-    const nonce = await getLastXCallNonce("1337", pool);
-    expect(nonce).equal(1);
-  });
-
-  it("should get last XCalled nonce with other domain nonce behind", async () => {
-    const xTransfer = mock.entity.xtransfer();
-    xTransfer.origin.xcall.timestamp = undefined;
-    xTransfer.nonce = 5;
-    xTransfer.chain = 1337;
-    await saveTransfers([xTransfer], pool);
-    const xTransfer2 = mock.entity.xtransfer();
-    xTransfer2.nonce = 111;
-    await saveTransfers([xTransfer2], pool);
-    const xTransfer3 = mock.entity.xtransfer();
-    xTransfer3.origin.xcall.timestamp = undefined;
-    xTransfer.nonce = 1;
-    xTransfer.chain = 1338;
-    await saveTransfers([xTransfer3], pool);
-    const nonce = await getLastXCallNonce("1337", pool);
-    expect(nonce).equal(5);
-  });
-
-  it("should get last XCalled nonce with other domain nonce ahead", async () => {
-    const xTransfer = mock.entity.xtransfer();
-    xTransfer.origin.xcall.timestamp = undefined;
-    xTransfer.nonce = 5;
-    xTransfer.chain = 1337;
-    await saveTransfers([xTransfer], pool);
-    const xTransfer2 = mock.entity.xtransfer();
-    xTransfer2.nonce = 111;
-    await saveTransfers([xTransfer2], pool);
-    const xTransfer3 = mock.entity.xtransfer();
-    xTransfer3.origin.xcall.timestamp = undefined;
-    xTransfer.nonce = 10;
-    xTransfer.chain = 1338;
-    await saveTransfers([xTransfer3], pool);
-    const nonce = await getLastXCallNonce("1337", pool);
-    expect(nonce).equal(5);
-  });
-
   it("should set a router balance", async () => {
     const routerBalances: RouterBalance[] = [
       {
@@ -485,12 +436,6 @@ describe("Database client", () => {
   it("should get latest nonce when no data", async () => {
     const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
     const nonce = await getLatestNonce(xTransfer1.destinationDomain, pool);
-    expect(nonce).equal(0);
-  });
-
-  it("should get latest XCall nonce when no data", async () => {
-    const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
-    const nonce = await getLastXCallNonce(xTransfer1.destinationDomain, pool);
     expect(nonce).equal(0);
   });
 

--- a/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
+++ b/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
@@ -16,7 +16,6 @@ import { utils } from "ethers";
 import {
   getTransferByTransferId,
   getTransfersByStatus,
-  getLatestNonce,
   saveTransfers,
   saveRouterBalances,
   getLatestXCallTimestamp,
@@ -174,11 +173,6 @@ describe("Database client", () => {
     expect(statusTransfers.length).equal(0);
   });
 
-  it("should get latest nonce of new or unkonwn chain", async () => {
-    const nonce = await getLatestNonce("unknown_chain", pool);
-    expect(nonce).equal(0);
-  });
-
   it("should save single transfer", async () => {
     const xTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
     await saveTransfers([xTransfer], pool);
@@ -312,13 +306,6 @@ describe("Database client", () => {
     expect(dbTransfer.xparams.receiveLocal).equal(false);
   });
 
-  it("should get latest nonce", async () => {
-    const xTransfer = mock.entity.xtransfer();
-    await saveTransfers([xTransfer], pool);
-    const nonce = await getLatestNonce("1337", pool);
-    expect(nonce).equal(1234);
-  });
-
   it("should set a router balance", async () => {
     const routerBalances: RouterBalance[] = [
       {
@@ -444,12 +431,6 @@ describe("Database client", () => {
     await saveTransfers([xTransfer1, xTransfer2, xTransfer3], pool);
     const timestamp = await getLatestReconcileTimestamp(xTransfer1.destinationDomain, pool);
     expect(timestamp).equal(3);
-  });
-
-  it("should get latest nonce when no data", async () => {
-    const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
-    const nonce = await getLatestNonce(xTransfer1.destinationDomain, pool);
-    expect(nonce).equal(0);
   });
 
   it("should get latest xcall timestamp when no data", async () => {

--- a/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
+++ b/packages/agents/cartographer/poller/test/adapters/database/client.spec.ts
@@ -17,6 +17,7 @@ import {
   getTransferByTransferId,
   getTransfersByStatus,
   getLatestNonce,
+  getLastXCallNonce,
   saveTransfers,
   saveRouterBalances,
   getLatestExecuteTimestamp,
@@ -318,6 +319,54 @@ describe("Database client", () => {
     expect(nonce).equal(1234);
   });
 
+  it("should get last XCalled nonce", async () => {
+    const xTransfer = mock.entity.xtransfer();
+    xTransfer.origin.xcall.timestamp = undefined;
+    xTransfer.nonce = 1;
+    await saveTransfers([xTransfer], pool);
+    const xTransfer2 = mock.entity.xtransfer();
+    xTransfer2.nonce = 111;
+    await saveTransfers([xTransfer2], pool);
+    const nonce = await getLastXCallNonce("1337", pool);
+    expect(nonce).equal(1);
+  });
+
+  it("should get last XCalled nonce with other domain nonce behind", async () => {
+    const xTransfer = mock.entity.xtransfer();
+    xTransfer.origin.xcall.timestamp = undefined;
+    xTransfer.nonce = 5;
+    xTransfer.chain = 1337;
+    await saveTransfers([xTransfer], pool);
+    const xTransfer2 = mock.entity.xtransfer();
+    xTransfer2.nonce = 111;
+    await saveTransfers([xTransfer2], pool);
+    const xTransfer3 = mock.entity.xtransfer();
+    xTransfer3.origin.xcall.timestamp = undefined;
+    xTransfer.nonce = 1;
+    xTransfer.chain = 1338;
+    await saveTransfers([xTransfer3], pool);
+    const nonce = await getLastXCallNonce("1337", pool);
+    expect(nonce).equal(5);
+  });
+
+  it("should get last XCalled nonce with other domain nonce ahead", async () => {
+    const xTransfer = mock.entity.xtransfer();
+    xTransfer.origin.xcall.timestamp = undefined;
+    xTransfer.nonce = 5;
+    xTransfer.chain = 1337;
+    await saveTransfers([xTransfer], pool);
+    const xTransfer2 = mock.entity.xtransfer();
+    xTransfer2.nonce = 111;
+    await saveTransfers([xTransfer2], pool);
+    const xTransfer3 = mock.entity.xtransfer();
+    xTransfer3.origin.xcall.timestamp = undefined;
+    xTransfer.nonce = 10;
+    xTransfer.chain = 1338;
+    await saveTransfers([xTransfer3], pool);
+    const nonce = await getLastXCallNonce("1337", pool);
+    expect(nonce).equal(5);
+  });
+
   it("should set a router balance", async () => {
     const routerBalances: RouterBalance[] = [
       {
@@ -436,6 +485,12 @@ describe("Database client", () => {
   it("should get latest nonce when no data", async () => {
     const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
     const nonce = await getLatestNonce(xTransfer1.destinationDomain, pool);
+    expect(nonce).equal(0);
+  });
+
+  it("should get latest XCall nonce when no data", async () => {
+    const xTransfer1: XTransfer = mock.entity.xtransfer({ status: XTransferStatus.Executed });
+    const nonce = await getLastXCallNonce(xTransfer1.destinationDomain, pool);
     expect(nonce).equal(0);
   });
 

--- a/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
+++ b/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
@@ -100,6 +100,8 @@ describe("Backend operations", () => {
     getTransfersByStatusStub.onThirdCall().resolves(mockSubgraphResponse);
     const saveRouterBalancesStub = stub(dbClient, "saveRouterBalances");
     saveRouterBalancesStub.resolves();
+    const getLatestXCallTimestampStub = stub(dbClient, "getLatestXCallTimestamp");
+    getLatestXCallTimestampStub.resolves(0);
     const getLatestExecuteTimestampStub = stub(dbClient, "getLatestExecuteTimestamp");
     getLatestExecuteTimestampStub.resolves(0);
     const getLatestReconcileTimestampStub = stub(dbClient, "getLatestReconcileTimestamp");
@@ -120,6 +122,7 @@ describe("Backend operations", () => {
           getLatestNonce: dbClient.getLatestNonce,
           getTransfersByStatus: dbClient.getTransfersByStatus,
           saveRouterBalances: dbClient.saveRouterBalances,
+          getLatestXCallTimestamp: dbClient.getLatestXCallTimestamp,
           getLatestExecuteTimestamp: dbClient.getLatestExecuteTimestamp,
           getLatestReconcileTimestamp: dbClient.getLatestReconcileTimestamp,
         },

--- a/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
+++ b/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
@@ -92,8 +92,6 @@ describe("Backend operations", () => {
   beforeEach(() => {
     const saveTransfersStub = stub(dbClient, "saveTransfers");
     saveTransfersStub.resolves();
-    const getLatestNonceStub = stub(dbClient, "getLatestNonce");
-    getLatestNonceStub.resolves(10);
     const getTransfersByStatusStub = stub(dbClient, "getTransfersByStatus");
     getTransfersByStatusStub.onFirstCall().resolves(mockSubgraphResponse);
     getTransfersByStatusStub.onSecondCall().resolves(mockSubgraphResponse);
@@ -119,7 +117,6 @@ describe("Backend operations", () => {
         }),
         database: {
           saveTransfers: dbClient.saveTransfers,
-          getLatestNonce: dbClient.getLatestNonce,
           getTransfersByStatus: dbClient.getTransfersByStatus,
           saveRouterBalances: dbClient.saveRouterBalances,
           getLatestXCallTimestamp: dbClient.getLatestXCallTimestamp,


### PR DESCRIPTION
## Description
There is a race condition between the cartographer queries to origin and destination side of the transfer. The end state of the transfer in the DB differs depends on the ordering of these two queries.


<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [x] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective
Resolve race conditions and allow origin and destination side  updates to DB be idempotent and order independent.

<!--- Describe your changes in more detail -->

## Related Issue(s)
https://github.com/connext/nxtp/issues/1404
Fixes <!--- Please link to the issue here: -->
https://github.com/connext/nxtp/issues/1404
## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
