### PR TITLE
1430 as a user my transfer data should not have gaps

### DIFF
--- a/packages/adapters/subgraph/src/reader.ts
+++ b/packages/adapters/subgraph/src/reader.ts
@@ -9,6 +9,7 @@ import {
   RouterBalance,
   AssetBalance,
   SubgraphQueryByTimestampMetaParams,
+  SubgraphQueryByTransferIDsMetaParams,
 } from "@connext/nxtp-utils";
 
 import { getHelpers } from "./lib/helpers";
@@ -29,6 +30,8 @@ import {
   getDestinationTransfersByReconcileTimestampQuery,
   getOriginTransfersByXCallTimestampQuery,
   getMaxRoutersPerTransferQuery,
+  getOriginTransfersByIDsCombinedQuery,
+  getDestinationTransfersByIDsCombinedQuery,
 } from "./lib/operations";
 import { SubgraphMap } from "./lib/entities";
 
@@ -359,6 +362,46 @@ export class SubgraphReader {
   ): Promise<XTransfer[]> {
     const { execute, parser } = getHelpers();
     const xcalledXQuery = getDestinationTransfersByReconcileTimestampQuery(params);
+    const response = await execute(xcalledXQuery);
+
+    const transfers: any[] = [];
+    for (const key of response.keys()) {
+      const value = response.get(key);
+      transfers.push(value?.flat());
+    }
+
+    const destinationTransfers: XTransfer[] = transfers
+      .flat()
+      .filter((x: any) => !!x)
+      .map(parser.destinationTransfer);
+
+    return destinationTransfers;
+  }
+
+  public async getOriginTransfersById(params: Map<string, SubgraphQueryByTransferIDsMetaParams>): Promise<XTransfer[]> {
+    const { execute, parser } = getHelpers();
+    const xcalledXQuery = getOriginTransfersByIDsCombinedQuery(params);
+    const response = await execute(xcalledXQuery);
+
+    const transfers: any[] = [];
+    for (const key of response.keys()) {
+      const value = response.get(key);
+      transfers.push(value?.flat());
+    }
+
+    const originTransfers: XTransfer[] = transfers
+      .flat()
+      .filter((x: any) => !!x)
+      .map(parser.originTransfer);
+
+    return originTransfers;
+  }
+
+  public async getDestinationTransfersById(
+    params: Map<string, SubgraphQueryByTransferIDsMetaParams>,
+  ): Promise<XTransfer[]> {
+    const { execute, parser } = getHelpers();
+    const xcalledXQuery = getDestinationTransfersByIDsCombinedQuery(params);
     const response = await execute(xcalledXQuery);
 
     const transfers: any[] = [];

--- a/packages/agents/cartographer/poller/db/migrations/20220617215641_transfers_update_time.sql
+++ b/packages/agents/cartographer/poller/db/migrations/20220617215641_transfers_update_time.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+ALTER TABLE transfers ADD column update_time timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.update_time = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_time_on_transfers
+    BEFORE UPDATE
+    ON transfers
+    FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+-- migrate:down
+

--- a/packages/agents/cartographer/poller/db/schema.sql
+++ b/packages/agents/cartographer/poller/db/schema.sql
@@ -22,6 +22,20 @@ CREATE TYPE public.transfer_status AS ENUM (
 );
 
 
+--
+-- Name: trigger_set_timestamp(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.trigger_set_timestamp() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  NEW.update_time = NOW();
+  RETURN NEW;
+END;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -138,7 +152,8 @@ CREATE TABLE public.transfers (
     callback character(42),
     recovery character(42),
     callback_fee numeric,
-    execute_relayer_fee numeric
+    execute_relayer_fee numeric,
+    update_time timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 
@@ -183,6 +198,13 @@ ALTER TABLE ONLY public.transfers
 
 
 --
+-- Name: transfers update_time_on_transfers; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER update_time_on_transfers BEFORE UPDATE ON public.transfers FOR EACH ROW EXECUTE FUNCTION public.trigger_set_timestamp();
+
+
+--
 -- Name: asset_balances fk_asset; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -209,4 +231,5 @@ ALTER TABLE ONLY public.asset_balances
 
 INSERT INTO public.schema_migrations (version) VALUES
     ('20220520150644'),
-    ('20220524141906');
+    ('20220524141906'),
+    ('20220617215641');

--- a/packages/agents/cartographer/poller/src/adapters/database/index.ts
+++ b/packages/agents/cartographer/poller/src/adapters/database/index.ts
@@ -5,6 +5,8 @@ import { getContext } from "../../shared";
 
 import {
   getTransfersByStatus,
+  getTransfersWithOriginPending,
+  getTransfersWithDestinationPending,
   saveTransfers,
   saveRouterBalances,
   getLatestXCallTimestamp,
@@ -21,6 +23,18 @@ export type Database = {
     orderDirection?: "ASC" | "DESC",
     _pool?: Pool,
   ) => Promise<XTransfer[]>;
+  getTransfersWithOriginPending: (
+    domain: string,
+    limit: number,
+    orderDirection?: "ASC" | "DESC",
+    _pool?: Pool,
+  ) => Promise<string[]>;
+  getTransfersWithDestinationPending: (
+    domain: string,
+    limit: number,
+    orderDirection?: "ASC" | "DESC",
+    _pool?: Pool,
+  ) => Promise<string[]>;
   saveRouterBalances: (routerBalances: RouterBalance[], _pool?: Pool) => Promise<void>;
   getLatestXCallTimestamp: (domain: string, _pool?: Pool) => Promise<number>;
   getLatestExecuteTimestamp: (domain: string, _pool?: Pool) => Promise<number>;
@@ -44,6 +58,8 @@ export const getDatabase = async (): Promise<Database> => {
   return {
     saveTransfers,
     getTransfersByStatus,
+    getTransfersWithOriginPending,
+    getTransfersWithDestinationPending,
     saveRouterBalances,
     getLatestXCallTimestamp,
     getLatestExecuteTimestamp,

--- a/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
+++ b/packages/agents/cartographer/poller/test/lib/operations/transfers.spec.ts
@@ -104,6 +104,10 @@ describe("Backend operations", () => {
     getLatestExecuteTimestampStub.resolves(0);
     const getLatestReconcileTimestampStub = stub(dbClient, "getLatestReconcileTimestamp");
     getLatestReconcileTimestampStub.resolves(0);
+    const getTransfersWithOriginPendingStub = stub(dbClient, "getTransfersWithOriginPending");
+    getTransfersWithOriginPendingStub.resolves([]);
+    const getTransfersWithDestinationPendingpStub = stub(dbClient, "getTransfersWithDestinationPending");
+    getTransfersWithDestinationPendingpStub.resolves([]);
 
     mockContext = {
       logger: new Logger({
@@ -122,6 +126,8 @@ describe("Backend operations", () => {
           getLatestXCallTimestamp: dbClient.getLatestXCallTimestamp,
           getLatestExecuteTimestamp: dbClient.getLatestExecuteTimestamp,
           getLatestReconcileTimestamp: dbClient.getLatestReconcileTimestamp,
+          getTransfersWithOriginPending: dbClient.getTransfersWithOriginPending,
+          getTransfersWithDestinationPending: dbClient.getTransfersWithDestinationPending,
         },
       },
       config: mockConfig as CartographerConfig,

--- a/packages/utils/src/peripherals/subgraph.ts
+++ b/packages/utils/src/peripherals/subgraph.ts
@@ -36,6 +36,11 @@ export type SubgraphQueryByTimestampMetaParams = {
   orderDirection?: "asc" | "desc";
 };
 
+export type SubgraphQueryByTransferIDsMetaParams = {
+  maxBlockNumber: number;
+  transferIDs: string[];
+};
+
 const MIN_SUBGRAPH_MAX_LAG = 25;
 export const SubgraphReaderChainConfigSchema = Type.Object({
   analytics: Type.Array(


### PR DESCRIPTION
## Description
Queries form cartographer to subgraphs use timestamps to checkpoint. This checkpoint mechanism because of quirks of how queries to subgraph work, are causing data gaps.


<!--- Provide a general summary of your changes in the Title above -->
Adding a new mechanism to monitor for data gaps, and fetch from subgraph, to close the gaps.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)
https://github.com/connext/nxtp/issues/1430
Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
