### PR TITLE
make sure domain is supported as sanity check in execute

### DIFF
--- a/packages/agents/lighthouse/src/lib/errors/cartographer.ts
+++ b/packages/agents/lighthouse/src/lib/errors/cartographer.ts
@@ -5,3 +5,13 @@ export class ApiRequestFailed extends NxtpError {
     super("Cartographer api request failed, waiting for next loop", context, ApiRequestFailed.name);
   }
 }
+
+export class DomainNotSupported extends NxtpError {
+  constructor(domain: string, transferId: string, context: any = {}) {
+    super(
+      "Destination domain for this transfer is not supported",
+      { ...context, domain, transferId },
+      DomainNotSupported.name,
+    );
+  }
+}


### PR DESCRIPTION
## Description
Seeing this error:
![image](https://user-images.githubusercontent.com/37907740/179090481-1deff6fb-3091-40a7-80d5-816325a06ce8.png)

Which occurs in the `catch` block in `packages/agents/lighthouse/src/lib/operations/cartographer.ts`.

```ts
      } catch (error: any) {
        logger.error("Error Cartographer Binding", requestContext, methodContext, jsonifyError(error as NxtpError), {
          transaction,
        });
      }
```

It seems it's likely being thrown here, in `packages/agents/lighthouse/src/lib/operations/relayer.ts`.
```ts
  const destinationConnextAddress = config.chains[args.params.destinationDomain].deployments.connext;
```

I guess we're just not checking beforehand that a domain for a given transfer is supported. While all domains *should* be supported in theory, we should still catch this case especially for debugging our staging environment / broken configurations.

## Type of change

Fire off an error, `DomainNotSupported`, if we don't have a given transfer's destination domain configured.

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code
