### PR TITLE
Subg mapping: `handleExecute`: no calculating router amount if slow liquidity transfer.

### DIFF
--- a/packages/deployments/subgraph/src/amarok-runtime-staging/mapping.ts
+++ b/packages/deployments/subgraph/src/amarok-runtime-staging/mapping.ts
@@ -271,13 +271,14 @@ export function handleExecuted(event: Executed): void {
     transfer = new DestinationTransfer(event.params.transferId.toHexString());
   }
 
-  const num = event.params.args.routers.length;
-  const amount = event.params.args.amount;
-  // TODO: Move from using hardcoded fee calc to using configured liquidity fee numerator.
-  const feesTaken = amount.times(BigInt.fromI32(5)).div(BigInt.fromI32(10000));
-  const routerAmount = amount.minus(feesTaken).div(BigInt.fromI32(num));
   const routers: string[] = [];
   if (transfer.status != "Reconciled") {
+    // Handle router asset balances if this is fast liquidity path.
+    const num = event.params.args.routers.length;
+    const amount = event.params.args.amount;
+    // TODO: Move from using hardcoded fee calc to using configured liquidity fee numerator.
+    const feesTaken = amount.times(BigInt.fromI32(5)).div(BigInt.fromI32(10000));
+    const routerAmount = amount.minus(feesTaken).div(BigInt.fromI32(num));
     for (let i = 0; i < num; i++) {
       const param = event.params.args.routers[i].toHex();
       let router = Router.load(param);

--- a/packages/deployments/subgraph/src/amarok-runtime-v0/mapping.ts
+++ b/packages/deployments/subgraph/src/amarok-runtime-v0/mapping.ts
@@ -271,13 +271,14 @@ export function handleExecuted(event: Executed): void {
     transfer = new DestinationTransfer(event.params.transferId.toHexString());
   }
 
-  const num = event.params.args.routers.length;
-  const amount = event.params.args.amount;
-  // TODO: Move from using hardcoded fee calc to using configured liquidity fee numerator.
-  const feesTaken = amount.times(BigInt.fromI32(5)).div(BigInt.fromI32(10000));
-  const routerAmount = amount.minus(feesTaken).div(BigInt.fromI32(num));
   const routers: string[] = [];
   if (transfer.status != "Reconciled") {
+    // Handle router asset balances if this is fast liquidity path.
+    const num = event.params.args.routers.length;
+    const amount = event.params.args.amount;
+    // TODO: Move from using hardcoded fee calc to using configured liquidity fee numerator.
+    const feesTaken = amount.times(BigInt.fromI32(5)).div(BigInt.fromI32(10000));
+    const routerAmount = amount.minus(feesTaken).div(BigInt.fromI32(num));
     for (let i = 0; i < num; i++) {
       const param = event.params.args.routers[i].toHex();
       let router = Router.load(param);


### PR DESCRIPTION
## Description

```
{
  "data": {
    "indexingStatuses": [
      {
        "subgraph": "QmVG5dgDYtufJHVfmHFFQcWRCRguiKoUFLZKRooJenkQxs",
        "synced": true,
        "health": "failed",
        "entityCount": "101",
        "fatalError": {
          "handler": null,
          "message": "attempted to divide BigInt `149925000000000000` by zero\twasm backtrace:\t    0: 0x5244 - <unknown>!~lib/@graphprotocol/graph-ts/common/numbers/BigInt#div\t    1: 0x562c - <unknown>!src/amarok-runtime-v0/mapping/handleExecuted\t in handler `handleExecuted` at block #7226475 (73c56944ebdc2ccdb8c0039a06836fd3158cb957d848c0b0c7e65670a23c3a1b)",
          "deterministic": true,
          "block": {
            "hash": "0x73c56944ebdc2ccdb8c0039a06836fd3158cb957d848c0b0c7e65670a23c3a1b",
            "number": "7226475"
          }
        },
        "chains": [
          {
            "chainHeadBlock": {
              "number": "7227477"
            },
            "earliestBlock": {
              "number": "7192754"
            },
            "latestBlock": {
              "number": "7226475"
            }
          }
        ]
      }
    ]
  }
}
```

This division by 0  in `handleExecute` was due to slow liquidity causing a denominator to be 0 . When calculating router amount, we divide the total amount after fees and split it between the routers. But we shouldn't be doing these calculations if it's a slow liquidity transfer.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code


