### PR TITLE
Re-add artifacts file to nxtp-contracts

### DIFF
--- a/packages/deployments/contracts/package.json
+++ b/packages/deployments/contracts/package.json
@@ -26,6 +26,7 @@
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/**/*",
+    "artifacts",
     "deployments.json",
     "contracts",
     "abi"


### PR DESCRIPTION
## Description

Fixes https://github.com/connext/nxtp/issues/1538.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

`artifacts` file in package.json was removed in https://github.com/connext/nxtp/commit/f893f302401fbef12872f02b95eaa14d1138f110.

The fix is to add it back.

Tested by `yarn pack`ing and installing local `nxtp-sdk` and `nxtp-contracts` packages into the bridge-ui. Artifacts get included and unresolved contracts are found.

Fixes <!--- Please link to the issue here: -->

https://github.com/connext/nxtp/issues/1538

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
