### PR TITLE
Spearbit 26

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/BaseConnextFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BaseConnextFacet.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import {Home} from "../../../nomad-core/contracts/Home.sol";
 
-import {AppStorage} from "../libraries/LibConnextStorage.sol";
+import {CallParams, AppStorage} from "../libraries/LibConnextStorage.sol";
 import {LibDiamond} from "../libraries/LibDiamond.sol";
 
 contract BaseConnextFacet {
@@ -94,5 +94,20 @@ contract BaseConnextFacet {
    */
   function _isAssetOwnershipRenounced() internal view returns (bool) {
     return LibDiamond.contractOwner() == address(0) || s._assetOwnershipRenounced;
+  }
+
+  /**
+   * @notice Calculates a transferId based on `xcall` arguments
+   * @dev Need this to prevent stack too deep
+   */
+  function _calculateTransferId(
+    CallParams calldata _params,
+    uint256 _amount,
+    uint256 _nonce,
+    bytes32 _canonicalId,
+    uint32 _canonicalDomain,
+    address _originSender
+  ) internal pure returns (bytes32) {
+    return keccak256(abi.encode(_nonce, _params, _originSender, _canonicalId, _canonicalDomain, _amount));
   }
 }

--- a/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/BridgeFacet.sol
@@ -566,21 +566,6 @@ contract BridgeFacet is BaseConnextFacet {
   }
 
   /**
-   * @notice Calculates a transferId based on `xcall` arguments
-   * @dev Need this to prevent stack too deep
-   */
-  function _calculateTransferId(
-    CallParams calldata _params,
-    uint256 _amount,
-    uint256 _nonce,
-    bytes32 _canonicalId,
-    uint32 _canonicalDomain,
-    address _originSender
-  ) private pure returns (bytes32) {
-    return keccak256(abi.encode(_nonce, _params, _originSender, _canonicalId, _canonicalDomain, _amount));
-  }
-
-  /**
    * @notice Calculates fast transfer amount.
    * @param _amount Transfer amount
    * @param _liquidityFeeNum Liquidity fee numerator

--- a/packages/deployments/contracts/contracts/core/connext/facets/PortalFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/PortalFacet.sol
@@ -8,7 +8,7 @@ import {BaseConnextFacet} from "./BaseConnextFacet.sol";
 import {IAavePool} from "../interfaces/IAavePool.sol";
 
 import {AssetLogic} from "../libraries/AssetLogic.sol";
-import {TokenId} from "../libraries/LibConnextStorage.sol";
+import {TokenId, CallParams} from "../libraries/LibConnextStorage.sol";
 
 contract PortalFacet is BaseConnextFacet {
   // ========== Custom Errors ===========
@@ -78,54 +78,71 @@ contract PortalFacet is BaseConnextFacet {
    * @param _maxIn The max value of the local asset to swap for the _backingAmount of adopted asset
    */
   function repayAavePortal(
+    CallParams calldata _params,
     address _local,
+    address _originSender,
+    uint256 _bridgedAmt,
+    uint256 _nonce,
     uint256 _backingAmount,
     uint256 _feeAmount,
-    uint256 _maxIn,
-    bytes32 _transferId
+    uint256 _maxIn
   ) external {
-    uint256 totalAmount = _backingAmount + _feeAmount; // in adopted
-    uint256 routerBalance = s.routerBalances[msg.sender][_local]; // in local
-
     // Sanity check: has that much to spend
-    if (routerBalance < _maxIn) revert PortalFacet__repayAavePortal_insufficientFunds();
+    if (s.routerBalances[msg.sender][_local] < _maxIn) revert PortalFacet__repayAavePortal_insufficientFunds();
+
+    // Here, generate the transfer id. This allows us to ensure the `_local` asset
+    // is the correct one associated with the transfer. Otherwise, anyone could pay back
+    // the loan with the incorrect asset and remove the ability to transfer here. If the
+    // `_local` asset is incorrectly supplied, the generated transferId will also be
+    // incorrect, and the _backLoan call (which manipulates the debt stored) will fail.
+    // Another option is to store the asset associated with the transfer on `execute`, but
+    // this would make an already expensive call even more so.
+    (uint32 domain, bytes32 id) = s.tokenRegistry.getTokenId(_local);
+    bytes32 transferId = _calculateTransferId(_params, _bridgedAmt, _nonce, id, domain, _originSender);
 
     // Need to swap into adopted asset or asset that was backing the loan
     // The router will always be holding collateral in the local asset while the loaned asset
     // is the adopted asset
 
     // Swap for exact `totalRepayAmount` of adopted asset to repay aave
-    (, bytes32 id) = s.tokenRegistry.getTokenId(_local);
-    (bool success, uint256 amountIn, address adopted) = AssetLogic.swapFromLocalAssetIfNeededForExactOut(
+    (bool success, uint256 amountDebited, address assetLoaned) = AssetLogic.swapFromLocalAssetIfNeededForExactOut(
       id,
       _local,
-      totalAmount,
+      _backingAmount + _feeAmount,
       _maxIn
     );
 
     if (!success) revert PortalFacet__repayAavePortal_swapFailed();
 
     // decrement router balances
-    s.routerBalances[msg.sender][_local] -= amountIn;
+    s.routerBalances[msg.sender][_local] -= amountDebited;
 
     // back loan
-    _backLoan(adopted, _backingAmount, _feeAmount, _transferId);
+    _backLoan(assetLoaned, _backingAmount, _feeAmount, transferId);
   }
 
   /**
    * @notice This allows anyone to repay the portal in the adopted asset for a given router
    * and transfer
+   *
    * @dev Should always be paying in the backing asset for the aave loan
+   *
+   * @param _params CallParams associated with the transfer
    * @param _adopted Address of the adopted asset (asset backing the loan)
+   * @param _originSender Original msg.sender of xcall on origin chain
+   * @param _bridgedAmt Amount bridged during transfer
+   * @param _nonce The nonce for the transfer
    * @param _backingAmount Amount of principle to repay
    * @param _feeAmount Amount of fees to repay
-   * @param _transferId Corresponding transfer id for the fees
    */
   function repayAavePortalFor(
+    CallParams calldata _params,
     address _adopted,
+    address _originSender,
+    uint256 _bridgedAmt,
+    uint256 _nonce,
     uint256 _backingAmount,
-    uint256 _feeAmount,
-    bytes32 _transferId
+    uint256 _feeAmount
   ) external payable {
     address adopted = _adopted == address(0) ? address(s.wrapper) : _adopted;
     // Ensure the asset is whitelisted
@@ -133,6 +150,22 @@ contract PortalFacet is BaseConnextFacet {
     if (canonical.id == bytes32(0)) {
       revert PortalFacet__repayAavePortalFor_notSupportedAsset();
     }
+
+    // Here, generate the transfer id. This allows us to ensure the `_adopted` asset
+    // is the correct one associated with the transfer. Otherwise, anyone could pay back
+    // the loan with the incorrect asset and remove the ability to transfer here. If the
+    // `_adopted` asset is incorrectly supplied, the generated transferId will also be
+    // incorrect, and the _backLoan call (which manipulates the debt stored) will fail.
+    // Another option is to store the asset associated with the transfer on `execute`, but
+    // this would make an already expensive call even more so.
+    bytes32 transferId = _calculateTransferId(
+      _params,
+      _bridgedAmt,
+      _nonce,
+      canonical.id,
+      canonical.domain,
+      _originSender
+    );
 
     // Transfer funds to the contract
     uint256 total = _backingAmount + _feeAmount;
@@ -163,7 +196,7 @@ contract PortalFacet is BaseConnextFacet {
 
     // No need to swap because this is the adopted asset. Simply
     // repay the loan
-    _backLoan(adopted, _backingAmount, _feeAmount, _transferId);
+    _backLoan(adopted, _backingAmount, _feeAmount, transferId);
   }
 
   // ============ Internal functions ============

--- a/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
@@ -246,19 +246,24 @@ interface IConnextHandler {
   function setAavePortalFee(uint256 _aavePortalFeeNumerator) external;
 
   function repayAavePortal(
-    address _asset,
+    CallParams calldata _params,
+    address _local,
+    address _originSender,
+    uint256 _bridgedAmt,
+    uint256 _nonce,
     uint256 _backingAmount,
     uint256 _feeAmount,
-    uint256 _maxIn,
-    bytes32 _transferId
+    uint256 _maxIn
   ) external;
 
   function repayAavePortalFor(
-    address _router,
+    CallParams calldata _params,
     address _adopted,
+    address _originSender,
+    uint256 _bridgedAmt,
+    uint256 _nonce,
     uint256 _backingAmount,
-    uint256 _feeAmount,
-    bytes32 _transferId
+    uint256 _feeAmount
   ) external;
 
   // StableSwapFacet

--- a/packages/deployments/contracts/contracts_forge/core/connext/facets/PortalFacet.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/facets/PortalFacet.t.sol
@@ -9,6 +9,7 @@ import {IDiamondCut} from "../../../../contracts/core/connext/interfaces/IDiamon
 
 import {BaseConnextFacet} from "../../../../contracts/core/connext/facets/BaseConnextFacet.sol";
 import {LibDiamond} from "../../../../contracts/core/connext/libraries/LibDiamond.sol";
+import {CallParams} from "../../../../contracts/core/connext/libraries/LibConnextStorage.sol";
 import {PortalFacet} from "../../../../contracts/core/connext/facets/PortalFacet.sol";
 import {TestAavePool} from "../../../../contracts/test/TestAavePool.sol";
 import {TestERC20} from "../../../../contracts/test/TestERC20.sol";
@@ -17,6 +18,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "../../../utils/Mock.sol";
 import "../../../utils/FacetHelper.sol";
+
+import "forge-std/console.sol";
 
 contract PortalFacetTest is PortalFacet, FacetHelper {
   // ============ Storage ============
@@ -27,7 +30,11 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
   address router = address(1111);
   address aavePool;
 
-  bytes32 _id = bytes32(abi.encodePacked(address(123)));
+  bytes32 transferId;
+  CallParams params;
+  address originSender = address(1232123);
+  uint256 bridgedAmt = 1 ether;
+  uint256 nonce = 89;
 
   // ============ Test set up ============
 
@@ -45,6 +52,50 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     aavePool = address(new MockPool(false));
     // set pool
     s.aavePool = aavePool;
+
+    params = CallParams(
+      address(11), // to
+      bytes(""), // callData
+      _originDomain, // origin domain
+      _destinationDomain, // destination domain
+      address(222222222), // agent
+      address(6666666), // recovery address
+      false, // forceSlow
+      false, // receiveLocal
+      address(0), // callback
+      0, // callbackFee
+      0, // relayer fee
+      9900 // slippageTol
+    );
+
+    // set default transfer id
+    transferId = utils_calculateTransferId();
+  }
+
+  // ============ Test utils ============
+
+  function utils_calculateTransferId() public returns (bytes32) {
+    console.log("canonical id");
+    console.logBytes32(_canonicalId);
+    return keccak256(abi.encode(nonce, params, originSender, _canonicalId, _canonicalDomain, bridgedAmt));
+  }
+
+  function utils_repayPortal(
+    CallParams memory p,
+    uint256 _backingAmount,
+    uint256 _feeAmount,
+    uint256 _maxIn
+  ) public {
+    this.repayAavePortal(p, _local, originSender, bridgedAmt, nonce, _backingAmount, _feeAmount, _maxIn);
+  }
+
+  function utils_repayPortalFor(
+    CallParams memory p,
+    address _adopted,
+    uint256 _backingAmount,
+    uint256 _feeAmount
+  ) public {
+    this.repayAavePortalFor(p, _adopted, originSender, bridgedAmt, nonce, _backingAmount, _feeAmount);
   }
 
   // ============ setAavePool ============
@@ -110,8 +161,8 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     // set liquidity
     uint256 init = 10 ether;
     s.routerBalances[router][_local] = init;
-    s.portalDebt[_id] = backing;
-    s.portalFeeDebt[_id] = fee;
+    s.portalDebt[transferId] = backing;
+    s.portalFeeDebt[transferId] = fee;
     assertTrue(IERC20(_local).balanceOf(address(this)) > init);
 
     // set mock for backing
@@ -123,7 +174,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     vm.expectEmit(true, true, true, true);
     emit AavePortalRouterRepayment(router, _local, backing, fee);
     vm.prank(router);
-    this.repayAavePortal(_local, backing, fee, backing, _id);
+    utils_repayPortal(params, backing, fee, backing);
 
     // assert balance decrement
     assertEq(s.routerBalances[router][_local], init - backing - fee);
@@ -144,7 +195,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     // call coming from router
     vm.prank(router);
     vm.expectRevert(abi.encodeWithSelector(PortalFacet.PortalFacet__repayAavePortal_insufficientFunds.selector));
-    this.repayAavePortal(_local, backing, fee, backing, _id);
+    utils_repayPortal(params, backing, fee, backing);
   }
 
   // fails if swap failed
@@ -174,7 +225,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     // call coming from router
     vm.prank(router);
     vm.expectRevert(abi.encodeWithSelector(PortalFacet.PortalFacet__repayAavePortal_swapFailed.selector));
-    this.repayAavePortal(_local, backing, fee, maxIn, _id);
+    utils_repayPortal(params, backing, fee, maxIn);
   }
 
   function test_PortalFacet__repayAavePortal_failsIfRepalyTooMuch() public {
@@ -193,8 +244,8 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     uint256 init = maxIn + 1;
 
     s.routerBalances[router][_local] = init;
-    s.portalDebt[_id] = backing - 1;
-    s.portalFeeDebt[_id] = fee - 1;
+    s.portalDebt[transferId] = backing - 1;
+    s.portalFeeDebt[transferId] = fee - 1;
 
     // set liquidity
     s.routerBalances[router][_local] = maxIn + 1;
@@ -212,7 +263,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
 
     vm.expectRevert(stdError.arithmeticError);
     vm.prank(router);
-    this.repayAavePortal(_local, backing, fee, maxIn, _id);
+    utils_repayPortal(params, backing, fee, maxIn);
 
     // assert balance decrement
     assertEq(s.routerBalances[router][_local], init);
@@ -221,6 +272,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
   function test_PortalFacet__repayAavePortal_shouldWorkUsingSwap() public {
     // we are on the destination domain where local != canonical
     utils_setupAsset(false, false);
+    transferId = utils_calculateTransferId();
 
     // set approval context
     s.routerPermissionInfo.approvedForPortalRouters[router] = true;
@@ -234,8 +286,8 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     uint256 init = maxIn + 1;
 
     s.routerBalances[router][_local] = init;
-    s.portalDebt[_id] = backing;
-    s.portalFeeDebt[_id] = fee;
+    s.portalDebt[transferId] = backing;
+    s.portalFeeDebt[transferId] = fee;
 
     // set liquidity
     s.routerBalances[router][_local] = maxIn + 1;
@@ -257,7 +309,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     vm.expectEmit(true, true, true, true);
     emit AavePortalRouterRepayment(router, _adopted, backing, fee);
     vm.prank(router);
-    this.repayAavePortal(_local, backing, fee, maxIn, _id);
+    utils_repayPortal(params, backing, fee, maxIn);
 
     // assert balance decrement
     assertEq(s.routerBalances[router][_local], init - amountIn);
@@ -278,7 +330,7 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     assertTrue(adopted != _adopted);
 
     vm.expectRevert(abi.encodeWithSelector(PortalFacet.PortalFacet__repayAavePortalFor_notSupportedAsset.selector));
-    this.repayAavePortalFor(adopted, backing, fee, _id);
+    utils_repayPortalFor(params, adopted, backing, fee);
   }
 
   // fails if zero amount
@@ -291,21 +343,24 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     utils_setupAsset(false, false);
 
     vm.expectRevert(abi.encodeWithSelector(PortalFacet.PortalFacet__repayAavePortalFor_zeroAmount.selector));
-    this.repayAavePortalFor(_adopted, backing, fee, _id);
+    utils_repayPortalFor(params, _adopted, backing, fee);
   }
 
   // should work
   function test_PortalFacet__repayAavePortalFor_shouldWork() public {
     // we are on the destination domain where local != canonical
     utils_setupAsset(false, false);
+    transferId = utils_calculateTransferId();
 
     // set debt amount
     uint256 backing = 1111;
     uint256 fee = 111;
     uint256 total = backing + fee;
 
-    s.portalDebt[_id] = backing;
-    s.portalFeeDebt[_id] = fee;
+    s.portalDebt[transferId] = backing;
+    s.portalFeeDebt[transferId] = fee;
+    console.log("repaying transfer id...");
+    console.logBytes32(transferId);
 
     // mint initial balance to sender and approve
     address sender = address(111);
@@ -319,11 +374,12 @@ contract PortalFacetTest is PortalFacet, FacetHelper {
     vm.expectEmit(true, true, true, true);
     emit AavePortalRouterRepayment(sender, _adopted, backing, fee);
     vm.prank(sender);
-    this.repayAavePortalFor(_adopted, backing, fee, _id);
+    utils_repayPortalFor(params, _adopted, backing, fee);
+    console.log("repaid");
 
     // assert balance decrement
     assertEq(IERC20(_adopted).balanceOf(sender), 0);
-    assertEq(s.portalDebt[_id], 0);
-    assertEq(s.portalFeeDebt[_id], 0);
+    assertEq(s.portalDebt[transferId], 0);
+    assertEq(s.portalFeeDebt[transferId], 0);
   }
 }


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Fixes spear bit issue #26 where portals could be repaid with any supported asset.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

- Updates the interface of the `repay*` functions to take in necessary info to generate `transferId`
- `transferId` is calculated onchain, based on canonical token information retrieved by asset
- If the supplied asset is incorrect, then the `transferId` will be generated incorrectly and the `portalDebt` checks would fail

## Related Issue(s)

Fixes spearbit #26

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
