### PR TITLE
Spearbit-74: delete router's aave portal approval status when removeRouter is called

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/RoutersFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/RoutersFacet.sol
@@ -322,6 +322,9 @@ contract RoutersFacet is BaseConnextFacet {
     // Clear any proposed ownership changes
     delete s.routerPermissionInfo.proposedRouterOwners[router];
     delete s.routerPermissionInfo.proposedRouterTimestamp[router];
+
+    // Clear approvedForPortal status.
+    delete s.routerPermissionInfo.approvedForPortalRouters[router];
   }
 
   /**

--- a/packages/deployments/contracts/contracts_forge/core/connext/facets/RoutersFacet.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/facets/RoutersFacet.t.sol
@@ -240,6 +240,7 @@ contract RoutersFacetTest is RoutersFacet, FacetHelper {
     assertEq(s.routerPermissionInfo.routerRecipients[_routerAgent0], address(0));
     assertEq(s.routerPermissionInfo.proposedRouterOwners[_routerAgent0], address(0));
     assertEq(s.routerPermissionInfo.proposedRouterTimestamp[_routerAgent0], 0);
+    assertEq(s.routerPermissionInfo.approvedForPortalRouters[_routerAgent0], address(0));
   }
 
   function test_RoutersFacet__removeRouter_failsIfNotOwner() public {


### PR DESCRIPTION
https://github.com/spearbit-audits/connext/issues/74