### PR TITLE
Spearbit 70: admin burnable

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/helpers/LPToken.sol
+++ b/packages/deployments/contracts/contracts/core/connext/helpers/LPToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.15;
 
-import {ERC20BurnableUpgradeable, ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
@@ -10,7 +10,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  * It is used to represent user's shares when providing liquidity to swap contracts.
  * @dev Only Swap contracts should initialize and own LPToken contracts.
  */
-contract LPToken is ERC20BurnableUpgradeable, OwnableUpgradeable {
+contract LPToken is ERC20Upgradeable, OwnableUpgradeable {
   // ============ Upgrade Gap ============
 
   uint256[49] private __GAP; // gap for upgrade safety
@@ -60,6 +60,17 @@ contract LPToken is ERC20BurnableUpgradeable, OwnableUpgradeable {
       _mint(address(1), MINIMUM_LIQUIDITY);
     }
     _mint(recipient, amount);
+  }
+
+  /**
+   * @notice Burns the given amount of LPToken from provided account
+   * @dev only owner can call this burn function
+   * @param account address of account from which to burn token
+   * @param amount amount of tokens to mint
+   */
+  function burnFrom(address account, uint256 amount) external onlyOwner {
+    require(amount != 0, "LPToken: cannot burn 0");
+    _burn(account, amount);
   }
 
   // ============ Internal functions ============


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/spearbit-audits/connext/issues/70

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

- `LPToken` now only inherits from `ERC20Upgradeable`
- Implement a `burnFrom` function that is  `onlyOwner` callable

## Related Issue(s)

Fixes https://github.com/spearbit-audits/connext/issues/70

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
