### PR TITLE
Add sender check

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
@@ -12,6 +12,7 @@ import {AssetLogic} from "../libraries/AssetLogic.sol";
 
 import {IAavePool} from "../interfaces/IAavePool.sol";
 import {IBridgeRouter} from "../interfaces/IBridgeRouter.sol";
+import {IBridgeHook} from "../interfaces/IBridgeHook.sol";
 
 import {BaseConnextFacet} from "./BaseConnextFacet.sol";
 
@@ -21,15 +22,16 @@ import {BaseConnextFacet} from "./BaseConnextFacet.sol";
  * the transfer
  *
  */
-contract NomadFacet is BaseConnextFacet {
+contract NomadFacet is BaseConnextFacet, IBridgeHook {
   // ============ Libraries ============
   using TypedMemView for bytes;
   using TypedMemView for bytes29;
 
   // ========== Custom Errors ===========
+  error NomadFacet__setBridgeRouter_invalidBridge();
+  error NomadFacet__reconcile_notConnext();
   error NomadFacet__reconcile_alreadyReconciled();
   error NomadFacet__reconcile_noPortalRouter();
-  error NomadFacet__setBridgeRouter_invalidBridge();
 
   // ============ Events ============
 
@@ -92,23 +94,31 @@ contract NomadFacet is BaseConnextFacet {
    * @dev Should be interface compatible with interface defined here:
    * https://github.com/nomad-xyz/monorepo/blob/main/packages/contracts-bridge/contracts/interfaces/IBridgeHook.sol
    *
+   * @param _sender - The msg.sender of the original bridge call on origin domain
    * @param _localToken - The address of the token representation on this domain, or the canonical
    * address if you are on the canonical domain
    * @param _amount - The amount bridged
    * @param _extraData - The extra data passed with the transfer on `sendToHook` (in this case transferId)
    */
   function onReceive(
-    uint32, // _origin, not used
+    uint32 _origin, // _origin, not used
+    bytes32 _sender,
     uint32 _tokenDomain, // of canonical token not used
     bytes32 _tokenAddress, // of canonical token
     address _localToken,
     uint256 _amount,
     bytes memory _extraData
   ) external onlyBridgeRouter {
+    // Assert sender was the connext contract on the origin domain
+    if (s.connextions[_origin] != _sender) {
+      revert NomadFacet__reconcile_notConnext();
+    }
+
     // Calculate the transfer id
-    // NOTE: anyone can use nomad to send to this hook. that means instead of sending through the
-    // transferId directly, it should be reconstructed here with the information included in nomad.
-    // meaning all xcall, execute, and reconcile data must match
+    // NOTE: Rather than sending the transferId through directly, recalculate the information here, to ensure
+    // it was transported correctly to ensure all xcall, execute, and reconcile data must match. The sender
+    // is asserted to be the connext contract on that domain, so this check could be unneccessary, but since
+    // the implications of incorrectly transferred data are severe
     TransferIdInformation memory info = abi.decode(_extraData, (TransferIdInformation));
     bytes32 transferId = _calculateTransferId(
       info.params,

--- a/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
@@ -113,7 +113,7 @@ contract NomadFacet is BaseConnextFacet, IBridgeHook {
     bytes memory _extraData
   ) external onlyBridgeRouter {
     // Assert sender was the connext contract on the origin domain
-    if (s.connextions[_origin] != _sender) {
+    if (_sender == bytes32(0) || s.connextions[_origin] != _sender) {
       revert NomadFacet__reconcile_notConnext();
     }
 

--- a/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
+++ b/packages/deployments/contracts/contracts/core/connext/facets/NomadFacet.sol
@@ -94,14 +94,17 @@ contract NomadFacet is BaseConnextFacet, IBridgeHook {
    * @dev Should be interface compatible with interface defined here:
    * https://github.com/nomad-xyz/monorepo/blob/main/packages/contracts-bridge/contracts/interfaces/IBridgeHook.sol
    *
+   * @param _origin - The origin domain
    * @param _sender - The msg.sender of the original bridge call on origin domain
+   * @param _tokenDomain - The canonical domain of the token
+   * @param _tokenAddress - The canonical identifier of the token
    * @param _localToken - The address of the token representation on this domain, or the canonical
    * address if you are on the canonical domain
    * @param _amount - The amount bridged
    * @param _extraData - The extra data passed with the transfer on `sendToHook` (in this case transferId)
    */
   function onReceive(
-    uint32 _origin, // _origin, not used
+    uint32 _origin,
     bytes32 _sender,
     uint32 _tokenDomain, // of canonical token not used
     bytes32 _tokenAddress, // of canonical token

--- a/packages/deployments/contracts/contracts/core/connext/interfaces/IBridgeHook.sol
+++ b/packages/deployments/contracts/contracts/core/connext/interfaces/IBridgeHook.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+/**
+ * @title IBridgeHook
+ * @notice Contains the interface used by Connext contracts out of Nomad's
+ * BridgeRouter. The BridgeRouter will transfer funds to the destination address, then
+ * call the `onReceive` hook once the message has been processed.
+ *
+ * Taken from:
+ * https://github.com/nomad-xyz/monorepo/blob/main/packages/contracts-bridge/contracts/interfaces/IBridgeHook.sol
+ */
+interface IBridgeHook {
+  /**
+   * @notice Handles an incoming bridge transfer with some tokens and extra
+   * data. Takes any necessary actions for the hook's purposes.
+   *
+   * This function is intended to allow arbitrary post-bridge actions with
+   * tokens, at a user's discretion. E.g. recollateralize a CDP, exchange for
+   * other tokens, emit an event, etc.
+   *
+   * @dev This hook is called AFTER tokens have been transferred to the hook
+   * contract. If this hook errors, the bridge WILL NOT revert, and the hook
+   * contract will own those tokens. Hook contracts MUST have a recovery plan
+   * in place for these situations.
+   *
+   * @param _origin The domain of the chain from which the transfer originated
+   * @param _sender The identifier of the caller which sent the tokens over the bridge
+   * @param _tokenDomain The canonical deployment domain of the token
+   * @param _tokenAddress The identifier for the token on its canonical domain
+   * @param _localToken The local address of the token (its canonical
+   *                    address if it is local to this domain, otherwise its
+   *                    the address of its local representation).
+   * @param _amount The amount of token received over the bridge
+   * @param _extraData Extra user-specified data passed in to the origin chain
+   */
+  function onReceive(
+    uint32 _origin,
+    bytes32 _sender,
+    uint32 _tokenDomain,
+    bytes32 _tokenAddress,
+    address _localToken,
+    uint256 _amount,
+    bytes memory _extraData
+  ) external;
+}

--- a/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
+++ b/packages/deployments/contracts/contracts/core/connext/interfaces/IConnextHandler.sol
@@ -108,6 +108,7 @@ interface IConnextHandler is IDiamondLoupe, IDiamondCut {
 
   function onReceive(
     uint32 _origin,
+    bytes32 _sender,
     uint32 _tokenDomain,
     bytes32 _tokenAddress,
     address _localToken,

--- a/packages/deployments/contracts/contracts_forge/Connext.t.sol
+++ b/packages/deployments/contracts/contracts_forge/Connext.t.sol
@@ -709,6 +709,7 @@ contract ConnextTest is ForgeHelper, Deployer {
     vm.prank(_destinationBridgeRouter);
     _destinationConnext.onReceive(
       _origin, // origin, not used
+      TypeCasts.addressToBytes32(address(_originConnext)),
       _canonicalDomain,
       TypeCasts.addressToBytes32(_canonical),
       _destinationLocal,

--- a/packages/deployments/contracts/contracts_forge/core/connext/facets/SwapAdminFacet.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/facets/SwapAdminFacet.t.sol
@@ -379,6 +379,7 @@ contract SwapAdminFacetTest is SwapAdminFacet, StableSwapFacet, FacetHelper {
     emit SwapInitialized(
       canonicalId,
       SwapUtils.Swap({
+        key: canonicalId,
         initialA: a * AmplificationUtils.A_PRECISION,
         futureA: a * AmplificationUtils.A_PRECISION,
         swapFee: fee,

--- a/packages/deployments/contracts/contracts_forge/core/connext/libraries/AmplificationUtils.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/libraries/AmplificationUtils.t.sol
@@ -27,6 +27,7 @@ contract AmplificationUtilsTest is FacetHelper {
     _balances[1] = 100;
 
     swap = SwapUtils.Swap({
+      key: _canonicalId,
       initialA: 1000,
       futureA: 10000,
       initialATime: 100,

--- a/packages/deployments/contracts/contracts_forge/core/connext/libraries/AssetLogic.t.sol
+++ b/packages/deployments/contracts/contracts_forge/core/connext/libraries/AssetLogic.t.sol
@@ -63,6 +63,7 @@ contract AssetLogicTest is BaseConnextFacet, FacetHelper {
     _balances[0] = 100;
     _balances[1] = 100;
     SwapUtils.Swap memory swap = SwapUtils.Swap({
+        key: _canonicalId,
         initialA : 0,
         futureA : 0,
         initialATime: 0,


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Updates the interface of `onReceive` to include the added `_sender` field. Related to issues mentioned [here](https://github.com/spearbit-audits/connext/issues/82)

Requires #1376 

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [x] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

- Adds a `IBridgeHook` interface that mimics expected Nomad interface
- Makes the `NomadFacet` conform to the `IBridgeHook` interface
- Updates the `onReceive` interface to the latest nomad `BridgeRouter` interface
- Asserts the `_sender` is `Connext` on the origin domain

## Related Issue(s)

Fixes issues outlined in spearbit comments: https://github.com/spearbit-audits/connext/issues/82#issuecomment-1196956926

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
