### PR TITLE
Addition of new hourly metrics and transfer schema change

### DIFF
--- a/packages/agents/cartographer/api/metrics.md
+++ b/packages/agents/cartographer/api/metrics.md
@@ -5,9 +5,11 @@
 1. TTR & TTV by Transfers
 2. Daily Transfer Metrics
 3. Daily Volume Metrics
-4. TVL by Router
+4. Hourly Transfer Metrics
+5. Hourly Volume Metrics
+6. TVL by Router
 
-### TTR & TTV by Transfers
+### 1. TTR & TTV by Transfers
 
 #### Endpoint
 
@@ -73,7 +75,7 @@ This enpoint is an extention of transfers endpoint with TTR and TTV calculated f
 }
 ```
 
-### Daily Transfer Metrics
+### 2. Daily Transfer Metrics
 
 Aggreagte count the distinct transfer for a given trandfer_date.
 
@@ -144,7 +146,7 @@ Transfer parameters can be used to furter slice the data and do aggreagations on
 - Few aggreation can't be reaggreagted based on how the data is returned by the API.
 - User metric: `unique_user_count` can't be summed together by transfer parameters to get overall user count.
 
-### Daily Volume Metrics
+### 3. Daily Volume Metrics
 
 #### Endpoint
 
@@ -187,11 +189,75 @@ Transfer parameters can be used to furter slice the data and do aggreagations on
 - Total forced slow volume by router for a given asset
 - Total forced slow volume till date for a given asset
 
-### TVL by Routers
+### 4. Hourly Transfer metrics
 
 #### Endpoint
 
-`http://0.0.0.0:3000/daily_router_tvl`
+[http://0.0.0.0:3000/hourly_transfer_metrics](http://0.0.0.0:3000/hourly_transfer_metrics)
+
+This endpoint is similar as, `http://0.0.0.0:3000/daily_transfer_metrics` in terms on filters with exception of metrics aggregated on hourly basis.
+
+#### Sample data returned
+
+```json
+{
+  "transfer_hour": "2022-07-07T04:00:00+00:00",
+  "origin_chain": "1111",
+  "destination_chain": "3331",
+  "router": null,
+  "asset": "0x3ffc03f05d1869f493c7dbf913e636c6280e0ff9",
+  "transfer_count": 1,
+  "unique_user_count": 1,
+  "force_slow_transfer_count": 0,
+  "zero_amount_transfer_count": 0,
+  "xcalled_transfer_count": 1,
+  "executed_transfer_count": 0,
+  "reconciled_transfer_count": 0,
+  "completedfast_transfer_count": 0,
+  "completedslow_transfer_count": 0,
+  "fastpath_avg_ttv_in_secs": null,
+  "fastpath_avg_ttr_in_secs": null,
+  "slowpath_avg_ttv_in_secs": null,
+  "slowpath_avg_ttr_in_secs": null
+}
+```
+
+#### Aggregations on top of this endpoint
+
+Simmilar to Daily Transfer Metrics.
+
+### 5. Hourly Transfer Volume
+
+#### Endpoint
+
+[http://0.0.0.0:3000/hourly_transfer_volume](http://0.0.0.0:3000/hourly_transfer_volume)
+
+This endpoint is similar as, `http://0.0.0.0:3000/daily_transfer_volume` in terms of filters with exception of metrics aggregated on hourly basis.
+
+#### Sample data returned
+
+```json
+{
+  "status": "XCalled",
+  "transfer_hour": "2022-07-11T19:00:00+00:00",
+  "origin_chain": "1111",
+  "destination_chain": "3331",
+  "router": null,
+  "asset": "0x3ffc03f05d1869f493c7dbf913e636c6280e0ff9",
+  "volume": 3700000000000000000000,
+  "force_slow_transfer_volume": 0
+}
+```
+
+#### Aggregations on top of this endpoint
+
+Simmilar to Daily Transfer Metrics.
+
+### 6. TVL by Routers
+
+#### Endpoint
+
+[http://0.0.0.0:3000/daily_router_tvl](http://0.0.0.0:3000/daily_router_tvl)
 
 - Aggreagtions:
 

--- a/packages/agents/cartographer/poller/db/migrations/20220730013440_min_outs.sql
+++ b/packages/agents/cartographer/poller/db/migrations/20220730013440_min_outs.sql
@@ -1,4 +1,4 @@
 -- migrate:up
-ALTER TABLE transfers DROP COLUMN slippage_tol;
-ALTER TABLE transfers ADD COLUMN destination_min_out numeric;
+-- ALTER TABLE transfers DROP COLUMN slippage_tol;
+-- ALTER TABLE transfers ADD COLUMN destination_min_out numeric;
 -- migrate:down

--- a/packages/agents/cartographer/poller/db/migrations/20220730013440_min_outs.sql
+++ b/packages/agents/cartographer/poller/db/migrations/20220730013440_min_outs.sql
@@ -1,4 +1,4 @@
 -- migrate:up
--- ALTER TABLE transfers DROP COLUMN slippage_tol;
--- ALTER TABLE transfers ADD COLUMN destination_min_out numeric;
+ALTER TABLE transfers DROP COLUMN slippage_tol;
+ALTER TABLE transfers ADD COLUMN destination_min_out numeric;
 -- migrate:down

--- a/packages/agents/cartographer/poller/db/migrations/20220824094332_metrics_transfer_add_fee_revenue.sql
+++ b/packages/agents/cartographer/poller/db/migrations/20220824094332_metrics_transfer_add_fee_revenue.sql
@@ -1,0 +1,130 @@
+-- migrate:up
+
+-- 
+-- Schema change
+-- 
+ALTER TABLE public.transfers
+ADD COLUMN IF NOT EXISTS transfer_status_update_by_agent numeric;
+
+ALTER TABLE public.transfers
+ADD COLUMN IF NOT EXISTS transfer_status_message_by_agent numeric;
+
+-- 
+-- New Hourly Metrics
+-- 
+-- 1. Transfer metrics
+CREATE  OR REPLACE VIEW public.hourly_transfer_metrics AS (
+    SELECT
+	-- filters:
+	date_trunc('hour', to_timestamp(tf.xcall_timestamp)) AS transfer_hour,
+	tf.origin_domain AS origin_chain,
+	tf.destination_domain AS destination_chain,
+	REGEXP_REPLACE(tf.routers::text, '[\{\}]', '', 'g') AS router,
+	tf.origin_transacting_asset AS asset,
+
+	-- aggs:
+	COUNT(tf.transfer_id) AS transfer_count,
+	COUNT(DISTINCT xcall_caller) AS unique_user_count,
+	COUNT(
+		CASE 
+		WHEN tf.force_slow IS True 
+		THEN tf.transfer_id 
+		END
+	) AS force_slow_transfer_count,
+	COUNT(
+		CASE WHEN tf.origin_bridged_amount = 0 
+		THEN tf.transfer_id 
+		END
+	) AS zero_amount_transfer_count,	
+	COUNT(
+		CASE 
+		WHEN tf.status = 'XCalled' 
+		THEN tf.transfer_id 
+		END	
+	) AS XCalled_transfer_count,
+	COUNT(
+		CASE 
+		WHEN tf.status = 'Executed' 
+		THEN tf.transfer_id 
+		END	
+	) AS Executed_transfer_count,
+	COUNT(
+		CASE 
+		WHEN tf.status = 'Reconciled' 
+		THEN tf.transfer_id 
+		END	
+	) AS Reconciled_transfer_count,
+	COUNT(
+		CASE 
+		WHEN tf.status = 'CompletedFast' 
+		THEN tf.transfer_id 
+		END	
+	) AS CompletedFast_transfer_count,	
+	COUNT(
+		CASE 
+		WHEN tf.status = 'CompletedSlow' 
+		THEN tf.transfer_id 
+		END	
+	) AS CompletedSlow_transfer_count,
+	AVG(
+		CASE 
+		WHEN tf.status = 'CompletedFast'
+		THEN tf.execute_timestamp - tf.xcall_timestamp
+		END
+	) AS FastPath_avg_ttv_in_secs,
+	AVG(
+		CASE 
+		WHEN tf.status = 'CompletedFast'
+		THEN tf.reconcile_timestamp - tf.xcall_timestamp 
+		END
+	) AS FastPath_avg_ttr_in_secs,
+	AVG(
+		CASE 
+		WHEN tf.status = 'CompletedSlow'
+		THEN (tf.execute_timestamp - tf.xcall_timestamp) 
+		END
+	) AS SlowPath_avg_ttv_in_secs,
+	AVG(
+		CASE 
+		WHEN tf.status = 'CompletedSlow'
+		THEN (tf.reconcile_timestamp - tf.xcall_timestamp)
+		END
+	) AS SlowPath_avg_ttr_in_secs
+
+    FROM public.transfers tf
+    GROUP BY 1,2,3,4,5
+    );
+	
+GRANT SELECT ON public.hourly_transfer_metrics to query;
+
+
+
+-- 2. Volume addition of new data
+CREATE  OR REPLACE VIEW public.hourly_transfer_volume AS ( 
+    SELECT 
+        tf.status,
+        date_trunc('hour', to_timestamp(tf.xcall_timestamp)) AS transfer_hour,
+        tf.origin_domain AS origin_chain,
+		tf.destination_domain AS destination_chain,
+        REGEXP_REPLACE(tf.routers::text, '[\{\}]', '', 'g') AS router,
+		tf.origin_transacting_asset AS asset,
+        SUM(tf.origin_transacting_amount) As volume,
+        COUNT(
+            CASE WHEN tf.force_slow IS True THEN tf.origin_transacting_amount END
+        ) AS force_slow_transfer_volume
+    FROM public.transfers tf
+    GROUP BY 1,2,3,4,5,6
+    );
+              
+GRANT SELECT ON public.hourly_transfer_volume to query;
+
+
+-- migrate:down
+ALTER TABLE public.transfers
+DROP COLUMN IF EXISTS transfer_status_update_by_agent;
+
+ALTER TABLE public.transfers
+DROP COLUMN IF EXISTS transfer_status_message_by_agent;
+
+DROP VIEW IF EXISTS public.hourly_transfer_metrics;
+DROP VIEW IF EXISTS public.hourly_transfer_volume;

--- a/packages/agents/cartographer/poller/db/migrations/20220824094332_metrics_transfer_add_fee_revenue.sql
+++ b/packages/agents/cartographer/poller/db/migrations/20220824094332_metrics_transfer_add_fee_revenue.sql
@@ -4,10 +4,10 @@
 -- Schema change
 -- 
 ALTER TABLE public.transfers
-ADD COLUMN IF NOT EXISTS transfer_status_update_by_agent numeric;
+ADD COLUMN IF NOT EXISTS transfer_status_update_by_agent character(42);
 
 ALTER TABLE public.transfers
-ADD COLUMN IF NOT EXISTS transfer_status_message_by_agent numeric;
+ADD COLUMN IF NOT EXISTS transfer_status_message_by_agent character(42);
 
 -- 
 -- New Hourly Metrics

--- a/packages/agents/cartographer/poller/db/schema.sql
+++ b/packages/agents/cartographer/poller/db/schema.sql
@@ -466,3 +466,4 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20220730013440'),
     ('20220811120125'),
     ('20220816134851');
+    ('20220824094332');


### PR DESCRIPTION
## Description

Addition of new metric endpoints: 

- `hourly_transfer_metrics`
- `hourly_transfer_volume`

Transfer schema alteration:
Addition of two columns to transfers, Details: https://github.com/connext/nxtp/issues/1689
- transfer_status_update_by_agent
- transfer_status_message_by_agent