### PR TITLE
Hot Fix: Reduce seq-sub concurrency to 2

### DIFF
--- a/ops/mainnet/prod/core/config.tf
+++ b/ops/mainnet/prod/core/config.tf
@@ -119,19 +119,19 @@ locals {
       queues = [
         {
           name       = "1"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "10"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "137"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         }

--- a/ops/testnet/prod/core/config.tf
+++ b/ops/testnet/prod/core/config.tf
@@ -128,19 +128,19 @@ locals {
       queues = [
         {
           name       = "1735356532"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "1735353714"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "9991"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         }

--- a/ops/testnet/staging/core/config.tf
+++ b/ops/testnet/staging/core/config.tf
@@ -128,19 +128,19 @@ locals {
       queues = [
         {
           name       = "1735353714"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "1735356532"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         },
         {
           name       = "9991"
-          limit      = 4
+          limit      = 2
           queueLimit = 10000
           subscribe  = true
         }


### PR DESCRIPTION
## Description

Hot Fix: Reduce seq-sub concurrency to 2
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [x] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
