### PR TITLE
Spearbit 235

### DIFF
--- a/packages/deployments/contracts/contracts/core/connext/helpers/BridgeToken.sol
+++ b/packages/deployments/contracts/contracts/core/connext/helpers/BridgeToken.sol
@@ -57,8 +57,7 @@ contract BridgeToken is IBridgeToken, Ownable, ERC20 {
    */
   function setDetails(string calldata _newName, string calldata _newSymbol) external override onlyOwner {
     // careful with naming convention change here
-    token.name = _newName;
-    token.symbol = _newSymbol;
+    _setDetails(_newName, _newSymbol);
     emit UpdateDetails(_newName, _newSymbol);
   }
 

--- a/packages/deployments/contracts/contracts/core/connext/helpers/OZERC20.sol
+++ b/packages/deployments/contracts/contracts/core/connext/helpers/OZERC20.sol
@@ -68,7 +68,7 @@ contract ERC20 is IERC20, IERC20Permit {
   uint256 private immutable _CACHED_CHAIN_ID;
   address private immutable _CACHED_THIS;
 
-  bytes32 private _HASHED_VERSION;
+  bytes32 private immutable _HASHED_VERSION;
   bytes32 private _HASHED_NAME;
 
   /**


### PR DESCRIPTION
## Description
Fix https://github.com/spearbit-audits/connext-nxtp/issues/235
<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->
The BridgeToken allows updating the name and symbol of a token. However the _CACHED_DOMAIN_SEPARATOR (of EIP712) isn't updated. This means that permit(), which uses _hashTypedDataV4() and _CACHED_DOMAIN_SEPARATOR still uses the old value.

On the other hand DOMAIN_SEPARATOR() is updated.
Both and especially their combination can give unexpected results.

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

https://github.com/spearbit-audits/connext-nxtp/issues/235

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
