### PR TITLE
Spearbit 74

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/connectors/gnosis/GnosisSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/gnosis/GnosisSpokeConnector.sol
@@ -52,6 +52,9 @@ contract GnosisSpokeConnector is SpokeConnector, GnosisBase {
    * @dev Messaging uses this function to send data to mainnet via amb
    */
   function _sendMessage(bytes memory _data) internal override {
+    // Should always be dispatching the aggregate root
+    require(_data.length == 32, "!length");
+
     // send the message to the l1 connector by calling `processMessage`
     GnosisAmb(AMB).requireToPassMessage(
       mirrorConnector,
@@ -64,6 +67,9 @@ contract GnosisSpokeConnector is SpokeConnector, GnosisBase {
    * @dev AMB calls this function to store aggregate root that is sent up by the root manager
    */
   function _processMessage(bytes memory _data) internal override {
+    // get the data (should be the aggregate root)
+    require(_data.length == 32, "!length");
+
     // ensure the l1 connector sent the message
     require(_verifySender(mirrorConnector), "!mirrorConnector");
     // ensure it is headed to this domain

--- a/packages/deployments/contracts/contracts/messaging/connectors/gnosis/GnosisSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/gnosis/GnosisSpokeConnector.sol
@@ -52,7 +52,7 @@ contract GnosisSpokeConnector is SpokeConnector, GnosisBase {
    * @dev Messaging uses this function to send data to mainnet via amb
    */
   function _sendMessage(bytes memory _data) internal override {
-    // Should always be dispatching the aggregate root
+    // Should always be dispatching the outbound root
     require(_data.length == 32, "!length");
 
     // send the message to the l1 connector by calling `processMessage`

--- a/packages/deployments/contracts/contracts/messaging/connectors/multichain/BaseMultichain.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/multichain/BaseMultichain.sol
@@ -37,6 +37,9 @@ abstract contract BaseMultichain {
    * @dev Sends `outboundRoot` to root manager on the mirror chain
    */
   function _sendMessage(address _amb, bytes memory _data) internal {
+    // Should always be dispatching the aggregate root
+    require(_data.length == 32, "!length");
+
     Multichain(_amb).anyCall(
       _amb, // Same address on every chain, using AMB as it is immutable
       _data,

--- a/packages/deployments/contracts/contracts/messaging/connectors/multichain/BaseMultichain.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/multichain/BaseMultichain.sol
@@ -37,7 +37,7 @@ abstract contract BaseMultichain {
    * @dev Sends `outboundRoot` to root manager on the mirror chain
    */
   function _sendMessage(address _amb, bytes memory _data) internal {
-    // Should always be dispatching the aggregate root
+    // Should always be dispatching the a merkle root
     require(_data.length == 32, "!length");
 
     Multichain(_amb).anyCall(

--- a/packages/deployments/contracts/contracts/messaging/connectors/optimism/OptimismSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/optimism/OptimismSpokeConnector.sol
@@ -49,6 +49,9 @@ contract OptimismSpokeConnector is SpokeConnector, BaseOptimism {
    * @dev Sends `outboundRoot` to root manager on l1
    */
   function _sendMessage(bytes memory _data) internal override {
+    // Should be 32 bytes aggregate root
+    require(_data.length == 32, "!length");
+
     bytes memory _calldata = abi.encodeWithSelector(Connector.processMessage.selector, _data);
     OptimismAmb(AMB).sendMessage(mirrorConnector, _calldata, uint32(mirrorGas));
   }

--- a/packages/deployments/contracts/contracts/messaging/connectors/optimism/OptimismSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/optimism/OptimismSpokeConnector.sol
@@ -49,7 +49,7 @@ contract OptimismSpokeConnector is SpokeConnector, BaseOptimism {
    * @dev Sends `outboundRoot` to root manager on l1
    */
   function _sendMessage(bytes memory _data) internal override {
-    // Should be 32 bytes aggregate root
+    // Should be 32 bytes outbound root
     require(_data.length == 32, "!length");
 
     bytes memory _calldata = abi.encodeWithSelector(Connector.processMessage.selector, _data);

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/multichain/MutlichainHubConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/multichain/MutlichainHubConnector.t.sol
@@ -40,6 +40,7 @@ contract MultichainHubConnectorTest is ConnectorHelper {
 
   // Happy path L1
   function test_MultichainHubConnector_sendMessage_sendMessageAndEmitEvent(bytes memory _data) public {
+    vm.assume(_data.length == 32);
     // Mock the call to anyCall
     vm.mockCall(
       _amb,


### PR DESCRIPTION
## Description
Fix https://github.com/spearbit-audits/connext-nxtp/issues/74
<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective
Description: The following functions do not validate that the input _data is 32 bytes.

GnosisSpokeConnector._sendMessage
GnosisSpokeConnector._processMessage
BaseMultichain.sendMessage
OptimismSpokeConnector._sendMessage
The input _data contains the outbound Merkle root or aggregated Merkle root, which is always 32 bytes. If the root is not 32 bytes, it is invalid and should be rejected.

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->
https://github.com/spearbit-audits/connext-nxtp/issues/74
## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
