### PR TITLE
fix: require symmetry

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/libraries/Queue.sol
+++ b/packages/deployments/contracts/contracts/messaging/libraries/Queue.sol
@@ -67,7 +67,7 @@ library QueueLib {
   ) internal returns (bytes32[] memory) {
     uint128 first = queue.first;
     uint128 last = queue.last;
-    require(last >= first, "queue empty");
+    require(!(first > last), "queue empty");
     require(first != 0, "queue !init'd");
     require(max > 0, "!acceptable max");
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Fixes: https://github.com/spearbit-audits/connext-nxtp/issues/56#issuecomment-1318324206

- Uses `require(!(first > last), "queue empty")` instead of `require(last >= first, "queue empty")`

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
