### PR TITLE
Fix typos across documentation, code, and tests

### DIFF
--- a/packages/agents/sequencer/test/bindings/server/server/index.spec.ts
+++ b/packages/agents/sequencer/test/bindings/server/server/index.spec.ts
@@ -166,7 +166,7 @@ describe("Bindings:Server", () => {
       expect(response.statusCode).to.be.eq(400);
     });
 
-    it("happy: should succeed to post a execute-slow data", async () => {
+    it("happy: should succeed to post an execute-slow data", async () => {
       (channel.publish as SinonStub).resolves();
       const mockExecutorData: ExecutorPostDataRequest = {
         transferId: mkBytes32(),

--- a/packages/deployments/contracts/contracts/messaging/connectors/optimism-v0/lib/RLPReader.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/optimism-v0/lib/RLPReader.sol
@@ -219,7 +219,7 @@ library RLPReader {
   }
 
   /**
-   * Reads an RLP address value into a address.
+   * Reads an RLP address value into an address.
    * @param _in RLP address value.
    * @return Decoded address.
    */
@@ -234,7 +234,7 @@ library RLPReader {
   }
 
   /**
-   * Reads an RLP address value into a address.
+   * Reads an RLP address value into an address.
    * @param _in RLP address value.
    * @return Decoded address.
    */

--- a/packages/deployments/contracts/contracts/shared/libraries/Multisend.sol
+++ b/packages/deployments/contracts/contracts/shared/libraries/Multisend.sol
@@ -18,7 +18,7 @@ contract MultiSend {
    * @dev Sends multiple transactions and reverts all if one fails.
    * @param transactions Encoded transactions. Each transaction is encoded as a packed bytes of
    *                     operation as a uint8 with 0 for a call or 1 for a delegatecall (=> 1 byte),
-   *                     to as a address (=> 20 bytes),
+   *                     to as an address (=> 20 bytes),
    *                     value as a uint256 (=> 32 bytes),
    *                     data length as a uint256 (=> 32 bytes),
    *                     data as bytes.

--- a/packages/integration/test/helpers/local/messages.ts
+++ b/packages/integration/test/helpers/local/messages.ts
@@ -11,7 +11,7 @@ import { PARAMETERS } from "../../constants/local";
 /**
  * Sends the spoke root via AMB.
  *
- * Even though we don't have the AMB configured in local test, we need to create an transaction for an event
+ * Even though we don't have the AMB configured in local test, we need to create a transaction for an event
  */
 export const sendSpokeRootToHub = async (
   spokeRootData: { domain: string; to: string },

--- a/packages/utils/src/helpers/multisend.ts
+++ b/packages/utils/src/helpers/multisend.ts
@@ -24,7 +24,7 @@ export const encodeMultisendCall = (txs: MultisendTransaction[]): string => {
           .solidityPack(
             [
               "uint8", // operation as a uint8 with 0 for a call or 1 for a delegatecall)
-              "address", // to as a address
+              "address", // to as an address
               "uint256", // value as a uint256 (must always be 0 in our txs as not payable)
               "uint256", // data length as a uint256
               "bytes", // data as bytes


### PR DESCRIPTION
This pull request addresses several typographical issues in documentation, code comments, and test files, improving clarity and readability across the project.

### Summary of Changes:
1. **Corrected "a address" to "an address"** in various files:
   - `index.spec.ts`: Updated test descriptions for grammatical correctness.
   - `RLPReader.sol`: Fixed multiple occurrences of "a address" in function comments.
   - `Multisend.sol`: Updated comment descriptions for encoding transactions.
   - `messages.ts`: Corrected "a transaction for an event" to ensure proper phrasing.
   - `multisend.ts`: Improved inline comments for clarity.

2. **Files Modified**:
   - `index.spec.ts`
   - `RLPReader.sol`
   - `Multisend.sol`
   - `messages.ts`
   - `multisend.ts`